### PR TITLE
Import dist version of awareness

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -2,7 +2,7 @@
 import * as Y from 'yjs'
 import { Decoration, DecorationSet } from 'prosemirror-view' // eslint-disable-line
 import { Plugin, PluginKey, EditorState, TextSelection } from 'prosemirror-state' // eslint-disable-line
-import { Awareness } from 'y-protocols/awareness.js' // eslint-disable-line
+import { Awareness } from 'y-protocols/dist/awareness.js' // eslint-disable-line
 import { ySyncPluginKey } from './sync-plugin.js'
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition } from '../lib.js'
 


### PR DESCRIPTION
This PR fixes bad require of `y-protocols/awareness` that makes unusable from node. Those library was being imported from ES6 version.