### PR TITLE
custom document layouts with y-prosemirror

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -142,7 +142,8 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
         update: () => {
           const pluginState = plugin.getState(view.state)
           if (pluginState.snapshot == null && pluginState.prevSnapshot == null) {
-            if (changedInitialContent || view.state.doc.content.size > 2) {
+            const emptySize = view.state.doc.createAndFill().content.size;
+            if (changedInitialContent || view.state.doc.content.size > emptySize) {
               changedInitialContent = true
               binding._prosemirrorChanged(view.state.doc)
             }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -142,7 +142,7 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
         update: () => {
           const pluginState = plugin.getState(view.state)
           if (pluginState.snapshot == null && pluginState.prevSnapshot == null) {
-            const emptySize = view.state.doc.createAndFill().content.size;
+            const emptySize = view.state.doc.type.createAndFill().content.size;
             if (changedInitialContent || view.state.doc.content.size > emptySize) {
               changedInitialContent = true
               binding._prosemirrorChanged(view.state.doc)


### PR DESCRIPTION
The following commit allows y-prosemirror to work with documents with forced, custom layouts. An example of this is a document with a required title, with the schema defined as `content: "title block+"`.

Previously, it was assumed that an empty ProseMirror document is a single paragraph node, with content size of 2. As a result, when ProseMirror initializes an empty document with a custom layout (with content size > 2), the sync-plugin erroneously triggers a call to `binding._prosemirrorChanged` even though the initial content has not changed. 

Because of this, yjs will not be able to initialize a serialized document correctly with `Y.applyUpdate(ydoc, ystate)`: instead of merging the nodes from `ystate` and the empty nodes created by the ProseMirror layout, it will duplicate the nodes. For example, instead of `["title", "paragraph"]`, yjs will initialize the document to `["title", "paragraph", "title", "paragraph"]`.

To calculate the size of an empty ProseMirror document with *any* custom layout, we use `view.state.doc` to obtain the node describing the schema (layout) and call `createAndFill().content.size` (ProseMirror documentation [here](https://prosemirror.net/docs/ref/#model.NodeType.createAndFill)). We then use this constant instead of 2 in the comparison for `changedInitialContent`.