### PR TITLE
Unexpected scroll in the prose mirror view by yjs update

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -14,6 +14,7 @@ import * as Y from 'yjs'
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition } from '../lib.js'
 import * as random from 'lib0/random.js'
 import * as environment from 'lib0/environment.js'
+import * as dom from 'lib0/dom.js'
 
 /**
  * @param {Y.Item} item
@@ -179,8 +180,8 @@ export const getRelativeSelection = (pmbinding, state) => ({
   head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping)
 })
 
-const getElementFromNode = node => {
-  if (node instanceof Element) {
+const getElementFromTextNode = node => {
+  if (dom.checkNodeType(node, dom.ELEMENT_NODE)) {
     return node
   }
   return node.parentElement
@@ -188,9 +189,9 @@ const getElementFromNode = node => {
 
 const isDomSelectionInView = () => {
   const selection = window.getSelection()
-  const anchorElement = getElementFromNode(selection.anchorNode)
+  const anchorElement = getElementFromTextNode(selection.anchorNode)
   if (selection && isInViewport(anchorElement)) {
-    const focusElement = getElementFromNode(selection.focusNode)
+    const focusElement = getElementFromTextNode(selection.focusNode)
     if (focusElement === anchorElement
       || focusElement === selection.anchorNode
       || selection.focusNode === focusElement
@@ -206,7 +207,7 @@ const isDomSelectionInView = () => {
 
 const isInViewport = element => {
   const bounding = element.getBoundingClientRect()
-  const documentElement = document.documentElement
+  const documentElement = dom.doc.documentElement
   return bounding.top >= 0 && bounding.left >= 0
     && bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
     && bounding.right <= (window.innerWidth || documentElement.clientWidth)

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -180,21 +180,6 @@ export const getRelativeSelection = (pmbinding, state) => ({
   head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping)
 })
 
-const getElementFromTextNode = node => {
-  if (dom.checkNodeType(node, dom.ELEMENT_NODE)) {
-    return node
-  }
-  return node.parentElement
-}
-
-const isInViewport = element => {
-  const bounding = element.getBoundingClientRect()
-  const documentElement = dom.doc.documentElement
-  return bounding.top >= 0 && bounding.left >= 0 &&
-    bounding.right <= (window.innerWidth || documentElement.clientWidth) &&
-    bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
-}
-
 /**
  * Binding for prosemirror.
  *
@@ -250,20 +235,17 @@ export class ProsemirrorBinding {
 
   _isDomSelectionInView () {
     const selection = this.prosemirrorView._root.getSelection()
-    const anchorElement = getElementFromTextNode(selection.anchorNode)
-    if (selection && isInViewport(anchorElement)) {
-      const focusElement = getElementFromTextNode(selection.focusNode)
-      if (focusElement === anchorElement ||
-        focusElement === selection.anchorNode ||
-        selection.focusNode === focusElement ||
-        selection.focusNode === selection.anchorNode ||
-        isInViewport(focusElement)
-      ) {
-        return true
-      }
-    }
 
-    return false
+    const range = this.prosemirrorView._root.createRange()
+    range.setStart(selection.anchorNode, selection.anchorOffset)
+    range.setEnd(selection.focusNode, selection.focusOffset)
+
+    const bounding = range.getBoundingClientRect()
+    const documentElement = dom.doc.documentElement
+
+    return bounding.top >= 0 && bounding.left >= 0 &&
+      bounding.right <= (window.innerWidth || documentElement.clientWidth) &&
+      bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
   }
 
   renderSnapshot (snapshot, prevSnapshot) {

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -316,9 +316,6 @@ export class ProsemirrorBinding {
       let tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
       tr = tr.setMeta(ySyncPluginKey, { isChangeOrigin: true })
-      if (this.beforeTransactionSelection !== null && this.prosemirrorView.hasFocus()) {
-        tr.scrollIntoView()
-      }
       this.prosemirrorView.dispatch(tr)
     })
   }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -184,7 +184,7 @@ const getElementFromNode = node => {
     return node
   }
   return node.parentElement
-};
+}
 
 const isDomSelectionInView = () => {
   const selection = window.getSelection()
@@ -202,7 +202,7 @@ const isDomSelectionInView = () => {
   }
 
   return false
-};
+}
 
 const isInViewport = element => {
   const bounding = element.getBoundingClientRect()
@@ -210,7 +210,7 @@ const isInViewport = element => {
   return bounding.top >= 0 && bounding.left >= 0
     && bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
     && bounding.right <= (window.innerWidth || documentElement.clientWidth)
-};
+}
 
 /**
  * Binding for prosemirror.
@@ -254,13 +254,13 @@ export class ProsemirrorBinding {
   }
 
   _isCurrentCursorInView() {
-    if (!this.prosemirrorView.hasFocus()) return false;
+    if (!this.prosemirrorView.hasFocus()) return false
     if (environment.isBrowser && this._domSelectionInView === null) {
       // Calculte the domSelectionInView and clear by next tick after all events are finished
-      setTimeout(() => this._domSelectionInView = null, 0);
-      this._domSelectionInView = isDomSelectionInView();
+      setTimeout(() => this._domSelectionInView = null, 0)
+      this._domSelectionInView = isDomSelectionInView()
     }
-    return this._domSelectionInView;
+    return this._domSelectionInView
   }
 
   renderSnapshot (snapshot, prevSnapshot) {

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -187,24 +187,6 @@ const getElementFromTextNode = node => {
   return node.parentElement
 }
 
-const isDomSelectionInView = () => {
-  const selection = window.getSelection()
-  const anchorElement = getElementFromTextNode(selection.anchorNode)
-  if (selection && isInViewport(anchorElement)) {
-    const focusElement = getElementFromTextNode(selection.focusNode)
-    if (focusElement === anchorElement ||
-      focusElement === selection.anchorNode ||
-      selection.focusNode === focusElement ||
-      selection.focusNode === selection.anchorNode ||
-      isInViewport(focusElement)
-    ) {
-      return true
-    }
-  }
-
-  return false
-}
-
 const isInViewport = element => {
   const bounding = element.getBoundingClientRect()
   const documentElement = dom.doc.documentElement
@@ -261,9 +243,27 @@ export class ProsemirrorBinding {
       setTimeout(() => {
         this._domSelectionInView = null
       }, 0)
-      this._domSelectionInView = isDomSelectionInView()
+      this._domSelectionInView = this._isDomSelectionInView()
     }
     return this._domSelectionInView
+  }
+
+  _isDomSelectionInView () {
+    const selection = this.prosemirrorView._root.getSelection()
+    const anchorElement = getElementFromTextNode(selection.anchorNode)
+    if (selection && isInViewport(anchorElement)) {
+      const focusElement = getElementFromTextNode(selection.focusNode)
+      if (focusElement === anchorElement ||
+        focusElement === selection.anchorNode ||
+        selection.focusNode === focusElement ||
+        selection.focusNode === selection.anchorNode ||
+        isInViewport(focusElement)
+      ) {
+        return true
+      }
+    }
+
+    return false
   }
 
   renderSnapshot (snapshot, prevSnapshot) {

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -192,11 +192,11 @@ const isDomSelectionInView = () => {
   const anchorElement = getElementFromTextNode(selection.anchorNode)
   if (selection && isInViewport(anchorElement)) {
     const focusElement = getElementFromTextNode(selection.focusNode)
-    if (focusElement === anchorElement
-      || focusElement === selection.anchorNode
-      || selection.focusNode === focusElement
-      || selection.focusNode === selection.anchorNode
-      || isInViewport(focusElement)
+    if (focusElement === anchorElement ||
+      focusElement === selection.anchorNode ||
+      selection.focusNode === focusElement ||
+      selection.focusNode === selection.anchorNode ||
+      isInViewport(focusElement)
     ) {
       return true
     }
@@ -208,9 +208,9 @@ const isDomSelectionInView = () => {
 const isInViewport = element => {
   const bounding = element.getBoundingClientRect()
   const documentElement = dom.doc.documentElement
-  return bounding.top >= 0 && bounding.left >= 0
-    && bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
-    && bounding.right <= (window.innerWidth || documentElement.clientWidth)
+  return bounding.top >= 0 && bounding.left >= 0 &&
+    bounding.right <= (window.innerWidth || documentElement.clientWidth) &&
+    bounding.bottom <= (window.innerHeight || documentElement.clientHeight)
 }
 
 /**
@@ -254,11 +254,13 @@ export class ProsemirrorBinding {
     this._domSelectionInView = null
   }
 
-  _isLocalCursorInView() {
+  _isLocalCursorInView () {
     if (!this.prosemirrorView.hasFocus()) return false
     if (environment.isBrowser && this._domSelectionInView === null) {
       // Calculte the domSelectionInView and clear by next tick after all events are finished
-      setTimeout(() => this._domSelectionInView = null, 0)
+      setTimeout(() => {
+        this._domSelectionInView = null
+      }, 0)
       this._domSelectionInView = isDomSelectionInView()
     }
     return this._domSelectionInView

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -253,7 +253,7 @@ export class ProsemirrorBinding {
     this._domSelectionInView = null
   }
 
-  _isCurrentCursorInView() {
+  _isLocalCursorInView() {
     if (!this.prosemirrorView.hasFocus()) return false
     if (environment.isBrowser && this._domSelectionInView === null) {
       // Calculte the domSelectionInView and clear by next tick after all events are finished
@@ -362,7 +362,7 @@ export class ProsemirrorBinding {
       let tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
       tr = tr.setMeta(ySyncPluginKey, { isChangeOrigin: true })
-      if (this.beforeTransactionSelection !== null && this._isCurrentCursorInView()) {
+      if (this.beforeTransactionSelection !== null && this._isLocalCursorInView()) {
         tr.scrollIntoView()
       }
       this.prosemirrorView.dispatch(tr)


### PR DESCRIPTION
What Happens:
1. There are 2 different clients connected to the same room (ClientA, ClientB) and they both have the cursor on the same prose mirror view (and thus both are focused on the view).
2. ClientA sets the cursor somewhere in the text field and scrolls up or down until the cursor is outside of the view.
3. ClientB types something in the same text field (it does not matter where).

Expected behaviour:
The view of ClientA should not scroll because the cursor of this client is not visible in the browser. 

Actual behaviour:
The view of ClientA will be scrolled back to where the client previously placed cursor.

Note: The issue is only reproducable with 2 different computers. If not the prose mirror view of one of the clients will lose focus when going the the other browser window.