### PR TITLE
Cusrsors with multiple prose mirror views in one yjs doc and awearness

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -32,14 +32,13 @@ export const defaultCursorBuilder = user => {
 }
 
 /**
- * @param {string} cursorStateName
  * @param {string} cursorId
  * @param {any} state
  * @param {Awareness} awareness
  * @param {Function} createCursor
  * @return {any} DecorationSet
  */
-export const createDecorations = (cursorStateName, cursorId, state, awareness, createCursor) => {
+export const createDecorations = (cursorId, state, awareness, createCursor) => {
   const ystate = ySyncPluginKey.getState(state)
   const y = ystate.doc
   const decorations = []
@@ -52,7 +51,7 @@ export const createDecorations = (cursorStateName, cursorId, state, awareness, c
     if (clientId === y.clientID) {
       return
     }
-    const cursorInfo = aw[cursorStateName]
+    const cursorInfo = aw.cursor
     if (cursorInfo != null && cursorInfo.cursorId === cursorId) {
       const user = aw.user || {}
       if (user.color == null) {
@@ -93,7 +92,6 @@ export const createDecorations = (cursorStateName, cursorId, state, awareness, c
  * @param {object} [opts]
  * @param {function(any):HTMLElement} [opts.cursorBuilder]
  * @param {function(any):any} [opts.getSelection]
- * @param {string} [opts.cursorStateName]
  * @param {any} [opts.cursorId]
  * @return {any}
  */
@@ -102,100 +100,97 @@ export const yCursorPlugin = (
   {
     cursorBuilder = defaultCursorBuilder,
     getSelection = state => state.selection,
-    cursorStateName = 'cursor',
     cursorId = null
   } = {}
-) => (
-  new Plugin({
-    key: yCursorPluginKey,
-    state: {
-      init (_, state) {
-        return createDecorations(cursorStateName, cursorId, state, awareness, cursorBuilder)
-      },
-      apply (tr, prevState, oldState, newState) {
-        const ystate = ySyncPluginKey.getState(newState)
-        const yCursorState = tr.getMeta(yCursorPluginKey)
-        if ((ystate && ystate.isChangeOrigin) || (yCursorState && yCursorState.awarenessUpdated)) {
-          return createDecorations(cursorStateName, cursorId, newState, awareness, cursorBuilder)
-        }
-        return prevState.map(tr.mapping, tr.doc)
-      }
+) => new Plugin({
+  key: yCursorPluginKey,
+  state: {
+    init (_, state) {
+      return createDecorations(cursorId, state, awareness, cursorBuilder)
     },
-    props: {
-      decorations: state => {
-        return yCursorPluginKey.getState(state)
+    apply (tr, prevState, oldState, newState) {
+      const ystate = ySyncPluginKey.getState(newState)
+      const yCursorState = tr.getMeta(yCursorPluginKey)
+      if ((ystate && ystate.isChangeOrigin) || (yCursorState && yCursorState.awarenessUpdated)) {
+        return createDecorations(cursorId, newState, awareness, cursorBuilder)
       }
-    },
-    view: view => {
-      const awarenessListener = () => {
-        // @ts-ignore
-        if (view.docView) {
-          setMeta(view, yCursorPluginKey, { awarenessUpdated: true })
+      return prevState.map(tr.mapping, tr.doc)
+    }
+  },
+  props: {
+    decorations: state => {
+      return yCursorPluginKey.getState(state)
+    }
+  },
+  view: view => {
+    const awarenessListener = () => {
+      // @ts-ignore
+      if (view.docView) {
+        setMeta(view, yCursorPluginKey, { awarenessUpdated: true })
+      }
+    }
+    const updateCursorInfo = () => {
+      const ystate = ySyncPluginKey.getState(view.state)
+
+      // @note We make implicit checks when checking for the cursor property
+      const current = awareness.getLocalState() || {}
+      const currentCursorInfo = current.cursor
+
+      if (view.hasFocus() && ystate.binding !== null) {
+        let shouldUpdateCursor = currentCursorInfo == null
+        const updateCursorInfo = {}
+
+        if (shouldUpdateCursor || currentCursorInfo.cursorId !== cursorId) {
+          updateCursorInfo.cursorId = cursorId
+          shouldUpdateCursor = true
         }
-      }
-      const updateCursorInfo = () => {
-        const ystate = ySyncPluginKey.getState(view.state)
 
-        // @note We make implicit checks when checking for the cursor property
-        const current = awareness.getLocalState() || {}
-        const currentCursorInfo = current[cursorStateName]
+        const selection = getSelection(view.state)
 
-        if (view.hasFocus() && ystate.binding !== null) {
-          let shouldUpdateCursor = currentCursorInfo == null
-          const updateCursorInfo = {}
-
-          if (shouldUpdateCursor || currentCursorInfo.cursorId !== cursorId) {
-            updateCursorInfo.cursorId = cursorId
-            shouldUpdateCursor = true
-          }
-
-          const selection = getSelection(view.state)
-
-          /**
-           * @type {Y.RelativePosition}
-           */
-          const anchor = absolutePositionToRelativePosition(selection.anchor, ystate.type, ystate.binding.mapping)
-          if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.anchor), anchor)) {
-            updateCursorInfo.anchor = anchor
-            shouldUpdateCursor = true
-          }
-
-          /**
-           * @type {Y.RelativePosition}
-           */
-          const head = absolutePositionToRelativePosition(selection.head, ystate.type, ystate.binding.mapping)
-          if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.head), head)) {
-            updateCursorInfo.head = head
-            shouldUpdateCursor = true
-          }
-
-          if (shouldUpdateCursor) {
-            awareness.setLocalStateField(cursorStateName, updateCursorInfo)
-          }
-        } else if (currentCursorInfo != null) {
-          if (currentCursorInfo.cursorId === cursorId) {
-            awareness.setLocalStateField(cursorStateName, null)
-          }
+        /**
+         * @type {Y.RelativePosition}
+         */
+        const anchor = absolutePositionToRelativePosition(selection.anchor, ystate.type, ystate.binding.mapping)
+        if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.anchor), anchor)) {
+          updateCursorInfo.anchor = anchor
+          shouldUpdateCursor = true
         }
-      }
-      awareness.on('change', awarenessListener)
-      view.dom.addEventListener('focusin', updateCursorInfo)
-      view.dom.addEventListener('focusout', updateCursorInfo)
-      return {
-        update: updateCursorInfo,
-        destroy: () => {
-          awareness.off('change', awarenessListener)
-          view.dom.removeEventListener('focusin', updateCursorInfo)
-          view.dom.removeEventListener('focusout', updateCursorInfo)
 
-          const current = awareness.getLocalState() || {}
-          const currentCursorInfo = current[cursorStateName]
+        /**
+         * @type {Y.RelativePosition}
+         */
+        const head = absolutePositionToRelativePosition(selection.head, ystate.type, ystate.binding.mapping)
+        if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.head), head)) {
+          updateCursorInfo.head = head
+          shouldUpdateCursor = true
+        }
 
-          if (currentCursorInfo.cursorId === cursorId) {
-            awareness.setLocalStateField(cursorStateName, null)
-          }
+        if (shouldUpdateCursor) {
+          awareness.setLocalStateField('cursor', updateCursorInfo)
+        }
+      } else if (currentCursorInfo != null) {
+        if (currentCursorInfo.cursorId === cursorId) {
+          awareness.setLocalStateField('cursor', null)
         }
       }
     }
-  })
-)
+    awareness.on('change', awarenessListener)
+    view.dom.addEventListener('focusin', updateCursorInfo)
+    view.dom.addEventListener('focusout', updateCursorInfo)
+    return {
+      update: updateCursorInfo,
+      destroy: () => {
+        awareness.off('change', awarenessListener)
+        view.dom.removeEventListener('focusin', updateCursorInfo)
+        view.dom.removeEventListener('focusout', updateCursorInfo)
+
+        const current = awareness.getLocalState() || {}
+        const currentCursorInfo = current.cursor
+
+        if (currentCursorInfo.cursorId === cursorId) {
+          awareness.setLocalStateField('cursor', null)
+        }
+      }
+    }
+  }
+})

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -44,8 +44,6 @@ export const createDecorations = (cursorStateName, cursorId, state, awareness, c
   const y = ystate.doc
   const decorations = []
 
-  const yType = ystate.type
-
   if (ystate.snapshot != null || ystate.prevSnapshot != null || ystate.binding === null) {
     // do not render cursors while snapshot is active
     return DecorationSet.create(state.doc, [])
@@ -63,8 +61,8 @@ export const createDecorations = (cursorStateName, cursorId, state, awareness, c
       if (user.name == null) {
         user.name = `User: ${clientId}`
       }
-      let anchor = relativePositionToAbsolutePosition(y, yType, Y.createRelativePositionFromJSON(cursorInfo.anchor), ystate.binding.mapping)
-      let head = relativePositionToAbsolutePosition(y, yType, Y.createRelativePositionFromJSON(cursorInfo.head), ystate.binding.mapping)
+      let anchor = relativePositionToAbsolutePosition(y, ystate.type, Y.createRelativePositionFromJSON(cursorInfo.anchor), ystate.binding.mapping)
+      let head = relativePositionToAbsolutePosition(y, ystate.type, Y.createRelativePositionFromJSON(cursorInfo.head), ystate.binding.mapping)
       if (anchor !== null && head !== null) {
         const maxsize = math.max(state.doc.content.size - 1, 0)
         anchor = math.min(anchor, maxsize)
@@ -134,8 +132,6 @@ export const yCursorPlugin = (awareness, {
     const updateCursorInfo = () => {
       const ystate = ySyncPluginKey.getState(view.state)
 
-      const yType = ystate.type
-
       // @note We make implicit checks when checking for the cursor property
       const current = awareness.getLocalState() || {}
       const currentCursorInfo = current[cursorStateName]
@@ -154,7 +150,7 @@ export const yCursorPlugin = (awareness, {
         /**
          * @type {Y.RelativePosition}
          */
-        const anchor = absolutePositionToRelativePosition(selection.anchor, yType, ystate.binding.mapping)
+        const anchor = absolutePositionToRelativePosition(selection.anchor, ystate.type, ystate.binding.mapping)
         if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.anchor), anchor)) {
           updateCursorInfo.anchor = anchor
           shouldUpdateCursor = true
@@ -163,7 +159,7 @@ export const yCursorPlugin = (awareness, {
         /**
          * @type {Y.RelativePosition}
          */
-        const head = absolutePositionToRelativePosition(selection.head, yType, ystate.binding.mapping)
+        const head = absolutePositionToRelativePosition(selection.head, ystate.type, ystate.binding.mapping)
         if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.head), head)) {
           updateCursorInfo.head = head
           shouldUpdateCursor = true

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -169,7 +169,6 @@ export const yCursorPlugin = (
         if (shouldUpdateCursor) {
           awareness.setLocalStateField('cursor', updateCursorInfo)
         }
-
       } else if (currentCursorInfo != null) {
         if (currentCursorInfo.cursorId === cursorId) {
           awareness.setLocalStateField('cursor', null)

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -151,16 +151,17 @@ export const yCursorPlugin = (
          * @type {Y.RelativePosition}
          */
         const anchor = absolutePositionToRelativePosition(selection.anchor, ystate.type, ystate.binding.mapping)
-        if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.anchor), anchor)) {
-          updateCursorInfo.anchor = anchor
-          shouldUpdateCursor = true
-        }
 
         /**
          * @type {Y.RelativePosition}
          */
         const head = absolutePositionToRelativePosition(selection.head, ystate.type, ystate.binding.mapping)
-        if (shouldUpdateCursor || !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.head), head)) {
+
+        if (shouldUpdateCursor ||
+          !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.head), head) ||
+          !Y.compareRelativePositions(Y.createRelativePositionFromJSON(currentCursorInfo.anchor), anchor)
+        ) {
+          updateCursorInfo.anchor = anchor
           updateCursorInfo.head = head
           shouldUpdateCursor = true
         }
@@ -168,6 +169,7 @@ export const yCursorPlugin = (
         if (shouldUpdateCursor) {
           awareness.setLocalStateField('cursor', updateCursorInfo)
         }
+
       } else if (currentCursorInfo != null) {
         if (currentCursorInfo.cursorId === cursorId) {
           awareness.setLocalStateField('cursor', null)

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -185,7 +185,15 @@ export const yCursorPlugin = (awareness, {
       update: updateCursorInfo,
       destroy: () => {
         awareness.off('change', awarenessListener)
-        awareness.setLocalStateField(cursorStateName, null)
+        view.dom.removeEventListener('focusin', updateCursorInfo)
+        view.dom.removeEventListener('focusout', updateCursorInfo)
+
+        const current = awareness.getLocalState() || {}
+        const currentCursorInfo = current[cursorStateName]
+
+        if (currentCursorInfo.cursorId === cursorId) {
+          awareness.setLocalStateField(cursorStateName, null)
+        }
       }
     }
   }


### PR DESCRIPTION
This is a optional parameter for the cursor plugin.
First I wanted to make an id of the _item.id to combine the client and the id. But when I checked it on a yXmlFragment on the root of the yDoc it seems that the _item was null. Maybe is missed something to get a unique id for each yXmlFragments.
The first implementation I tried all the cursors would be saved in a different key name in the awareness state. After the first test that was not a great solution. If you have a lot of prose mirror views there will also be a lot of keys in that awareness state. I kept this in when somebody wants to change the cursor state name.
After this I added an id in the cursor info and only rendered the cursor when the id is correct for that prose mirror view. I will also open a pr in the [yjs demo's](https://github.com/yjs/yjs-demos) where I changed the prose mirror example to 2 prose mirror views with cursors. That was also the case I used to test this.