### PR TITLE
feat: Add utility methods for conversion to/from Prosemirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,37 @@ const prosemirrorView = new EditorView(document.querySelector('#editor'), {
 })
 ```
 
+#### Utilities
+
+The package includes a number of utility methods for converting back and forth between
+a Y.Doc and Prosemirror compatible data structures. These can be useful for persisting
+to a datastore or for importing existing documents.
+
+> _Note_: Serializing and deserializing to JSON will not store collaboration history
+> steps and as such should not be used as the primary storage. You will still need
+> to store the Y.Doc binary update format.
+
+```js
+import { prosemirrorToYDoc } from 'y-prosemirror'
+
+// Pass JSON previously output from Prosemirror
+const doc = Node.fromJSON(schema, {
+  type: "doc",
+  content: [...]
+})
+const ydoc = prosemirrorToYDoc(doc)
+```
+
+```js
+import { yDocToProsemirror } from 'y-prosemirror'
+
+// apply binary updates from elsewhere
+const ydoc = new Y.Doc()
+ydoc.applyUpdate(update)
+
+const node = yDocToProsemirror(schema, ydoc)
+```
+
 ### License
 
 [The MIT License](./LICENSE) © Kevin Jahns

--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ const doc = Node.fromJSON(schema, {
 const ydoc = prosemirrorToYDoc(doc)
 ```
 
+Because JSON is a common usecase there is an equivalent method that skips the need
+to create a Prosemirror Node.
+
+```js
+import { prosemirrorJSONToYDoc } from 'y-prosemirror'
+
+// Pass JSON previously output from Prosemirror
+const ydoc = prosemirrorJSONToYDoc(schema, {
+  type: "doc",
+  content: [...]
+})
+```
+
 ```js
 import { yDocToProsemirror } from 'y-prosemirror'
 
@@ -151,6 +164,19 @@ const ydoc = new Y.Doc()
 ydoc.applyUpdate(update)
 
 const node = yDocToProsemirror(schema, ydoc)
+```
+
+Because JSON is a common usecase there is an equivalent method that outputs JSON
+directly, this method does not require the Prosemirror schema.
+
+```js
+import { yDocToProsemirrorJSON } from 'y-prosemirror'
+
+// apply binary updates from elsewhere
+const ydoc = new Y.Doc()
+ydoc.applyUpdate(update)
+
+const node = yDocToProsemirrorJSON(ydoc)
 ```
 
 ### License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,6 +1790,11 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true
     },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@rollup/plugin-commonjs": "^15.0.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "lib0": "^0.2.33",
+    "lodash.flatten": "^4.4.0",
     "rollup": "^2.26.11"
   },
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -65,5 +65,5 @@ export default [{
       mainFields: ['module', 'main']
     })
   ],
-  external: id => /^(lib0|prosemirror|fs|path|jsdom|isomorphic)/.test(id)
+  external: id => /^(lib0|lodash|prosemirror|fs|path|jsdom|isomorphic)/.test(id)
 }]

--- a/src/interface.js
+++ b/src/interface.js
@@ -120,5 +120,8 @@ export function yDocToProsemirrorJSON (
     return response
   }
 
-  return items.map(serialize)
+  return {
+    type: 'doc',
+    content: items.map(serialize)
+  }
 }

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,0 +1,124 @@
+// eslint-disable-next-line
+import { Node, Schema } from 'prosemirror-model'
+import flatten from 'lodash.flatten'
+import { updateYFragment } from './lib'
+import * as Y from 'yjs'
+
+/**
+ * Utility method to convert a Prosemirror Doc Node into a Y.Doc.
+ *
+ * This can be used when importing existing content to Y.Doc for the first time,
+ * note that this should not be used to rehydrate a Y.Doc from a database once
+ * collaboration has begun as all history will be lost
+ *
+ * @param {Node} doc
+ * @param {string} xmlFragment
+ * @return {Y.Doc}
+ */
+export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
+  const ydoc = new Y.Doc()
+  const type = ydoc.get(xmlFragment, Y.XmlFragment)
+  if (!type.doc) {
+    return ydoc
+  }
+
+  return updateYFragment(type.doc, type, doc, new Map())
+}
+
+/**
+ * Utility method to convert Prosemirror compatible JSON into a Y.Doc.
+ *
+ * This can be used when importing existing content to Y.Doc for the first time,
+ * note that this should not be used to rehydrate a Y.Doc from a database once
+ * collaboration has begun as all history will be lost
+ *
+ * @param {Schema} schema
+ * @param {any} state
+ * @param {string} xmlFragment
+ * @return {Y.Doc}
+ */
+export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror') {
+  const doc = Node.fromJSON(schema, state)
+  return prosemirrorToYDoc(schema, doc, xmlFragment)
+}
+
+/**
+ * Utility method to convert a Y.Doc to a Prosemirror Doc node.
+ *
+ * @param {Schema} schema
+ * @param {Y.Doc} ydoc
+ * @return {Node}
+ */
+export function yDocToProsemirror (schema, ydoc) {
+  const state = yDocToProsemirrorJSON(ydoc)
+  return Node.fromJSON(schema, state)
+}
+
+/**
+ * Utility method to convert a Y.Doc to Prosemirror compatible JSON.
+ *
+ * @param {Y.Doc} ydoc
+ * @param {string} xmlFragment
+ * @return {Record<string, any>}
+ */
+export function yDocToProsemirrorJSON (
+  ydoc,
+  xmlFragment = 'prosemirror'
+) {
+  const items = ydoc.getXmlFragment(xmlFragment).toArray()
+
+  function serialize (item) {
+    /**
+     * @type {Object} NodeObject
+     * @property {string} NodeObject.type
+     * @property {Record<string, string>=} NodeObject.attrs
+     * @property {Array<NodeObject>=} NodeObject.content
+     */
+    let response
+
+    // TODO: Must be a better way to detect text nodes than this
+    if (!item.nodeName) {
+      const delta = item.toDelta()
+      response = delta.map((d) => {
+        const text = {
+          type: 'text',
+          text: d.insert
+        }
+
+        if (d.attributes) {
+          text.marks = Object.keys(d.attributes).map((type) => {
+            const attrs = d.attributes[type]
+            const mark = {
+              type
+            }
+
+            if (Object.keys(attrs)) {
+              mark.attrs = attrs
+            }
+
+            return mark
+          })
+        }
+        return text
+      })
+    } else {
+      response = {
+        type: item.nodeName
+      }
+
+      const attrs = item.getAttributes()
+      if (Object.keys(attrs).length) {
+        response.attrs = attrs
+      }
+
+      const children = item.toArray()
+      if (children.length) {
+        response.content = flatten(children.map(serialize))
+      }
+    }
+
+    return response
+  }
+
+  return items.map(serialize)
+}

--- a/src/interface.js
+++ b/src/interface.js
@@ -1,7 +1,7 @@
 // eslint-disable-next-line
 import { Node, Schema } from 'prosemirror-model'
 import flatten from 'lodash.flatten'
-import { updateYFragment } from './lib'
+import { updateYFragment } from './lib.js'
 import * as Y from 'yjs'
 
 /**
@@ -39,7 +39,7 @@ export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
  */
 export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror') {
   const doc = Node.fromJSON(schema, state)
-  return prosemirrorToYDoc(schema, doc, xmlFragment)
+  return prosemirrorToYDoc(doc, xmlFragment)
 }
 
 /**

--- a/src/lib.js
+++ b/src/lib.js
@@ -11,7 +11,7 @@ import * as eventloop from 'lib0/eventloop.js'
 import * as math from 'lib0/math.js'
 import * as object from 'lib0/object.js'
 import { simpleDiff } from 'lib0/diff.js'
-import { ySyncPluginKey } from './plugins/keys'
+import { ySyncPluginKey } from './plugins/keys.js'
 
 /**
  * @param {Y.Item} item
@@ -253,7 +253,7 @@ export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapsh
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact(transaction => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
-    }, ySyncPluginKey)
+  }, ySyncPluginKey)
     mapping.delete(el)
     return null
   }
@@ -285,7 +285,7 @@ export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSn
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (text.doc).transact(transaction => {
       /** @type {Y.Item} */ (text._item).delete(transaction)
-    }, ySyncPluginKey)
+  }, ySyncPluginKey)
     return null
   }
   // @ts-ignore

--- a/src/lib.js
+++ b/src/lib.js
@@ -3,9 +3,21 @@ import { ProsemirrorMapping } from './plugins/sync-plugin.js' // eslint-disable-
 import * as Y from 'yjs'
 // eslint-disable-next-line
 import { EditorView } from 'prosemirror-view'
+// eslint-disable-next-line
+import * as PModel from 'prosemirror-model'
 import * as error from 'lib0/error.js'
 import * as map from 'lib0/map.js'
 import * as eventloop from 'lib0/eventloop.js'
+import * as math from 'lib0/math.js'
+import * as object from 'lib0/object.js'
+import { simpleDiff } from 'lib0/diff.js'
+import { ySyncPluginKey } from './plugins/keys'
+
+/**
+ * @param {Y.Item} item
+ * @param {Y.Snapshot} [snapshot]
+ */
+export const isVisible = (item, snapshot) => snapshot === undefined ? !item.deleted : (snapshot.sv.has(item.id.client) && /** @type {number} */ (snapshot.sv.get(item.id.client)) > item.id.clock && !Y.isDeleted(snapshot.ds, item.id))
 
 /**
  * Is null if no timeout is in progress.
@@ -168,3 +180,443 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
   }
   return pos - 1 // we don't count the most outer tag, because it is a fragment
 }
+
+/**
+ * @private
+ * @param {Y.XmlElement | Y.XmlHook} el
+ * @param {PModel.Schema} schema
+ * @param {ProsemirrorMapping} mapping
+ * @param {Y.Snapshot} [snapshot]
+ * @param {Y.Snapshot} [prevSnapshot]
+ * @param {function('removed' | 'added', Y.ID):any} [computeYChange]
+ * @return {PModel.Node | null}
+ */
+export const createNodeIfNotExists = (el, schema, mapping, snapshot, prevSnapshot, computeYChange) => {
+  const node = /** @type {PModel.Node} */ (mapping.get(el))
+  if (node === undefined) {
+    if (el instanceof Y.XmlElement) {
+      return createNodeFromYElement(el, schema, mapping, snapshot, prevSnapshot, computeYChange)
+    } else {
+      throw error.methodUnimplemented() // we are currently not handling hooks
+    }
+  }
+  return node
+}
+
+/**
+ * @private
+ * @param {Y.XmlElement} el
+ * @param {any} schema
+ * @param {ProsemirrorMapping} mapping
+ * @param {Y.Snapshot} [snapshot]
+ * @param {Y.Snapshot} [prevSnapshot]
+ * @param {function('removed' | 'added', Y.ID):any} [computeYChange]
+ * @return {PModel.Node | null} Returns node if node could be created. Otherwise it deletes the yjs type and returns null
+ */
+export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapshot, computeYChange) => {
+  const children = []
+  const createChildren = type => {
+    if (type.constructor === Y.XmlElement) {
+      const n = createNodeIfNotExists(type, schema, mapping, snapshot, prevSnapshot, computeYChange)
+      if (n !== null) {
+        children.push(n)
+      }
+    } else {
+      const ns = createTextNodesFromYText(type, schema, mapping, snapshot, prevSnapshot, computeYChange)
+      if (ns !== null) {
+        ns.forEach(textchild => {
+          if (textchild !== null) {
+            children.push(textchild)
+          }
+        })
+      }
+    }
+  }
+  if (snapshot === undefined || prevSnapshot === undefined) {
+    el.toArray().forEach(createChildren)
+  } else {
+    Y.typeListToArraySnapshot(el, new Y.Snapshot(prevSnapshot.ds, snapshot.sv)).forEach(createChildren)
+  }
+  try {
+    const attrs = el.getAttributes(snapshot)
+    if (snapshot !== undefined) {
+      if (!isVisible(/** @type {Y.Item} */(el._item), snapshot)) {
+        attrs.ychange = computeYChange ? computeYChange('removed', /** @type {Y.Item} */(el._item).id) : { type: 'removed' }
+      } else if (!isVisible(/** @type {Y.Item} */(el._item), prevSnapshot)) {
+        attrs.ychange = computeYChange ? computeYChange('added', /** @type {Y.Item} */(el._item).id) : { type: 'added' }
+      }
+    }
+    const node = schema.node(el.nodeName, attrs, children)
+    mapping.set(el, node)
+    return node
+  } catch (e) {
+    // an error occured while creating the node. This is probably a result of a concurrent action.
+    /** @type {Y.Doc} */ (el.doc).transact(transaction => {
+      /** @type {Y.Item} */ (el._item).delete(transaction)
+    }, ySyncPluginKey)
+    mapping.delete(el)
+    return null
+  }
+}
+
+/**
+ * @private
+ * @param {Y.XmlText} text
+ * @param {any} schema
+ * @param {ProsemirrorMapping} mapping
+ * @param {Y.Snapshot} [snapshot]
+ * @param {Y.Snapshot} [prevSnapshot]
+ * @param {function('removed' | 'added', Y.ID):any} [computeYChange]
+ * @return {Array<PModel.Node>|null}
+ */
+export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSnapshot, computeYChange) => {
+  const nodes = []
+  const deltas = text.toDelta(snapshot, prevSnapshot, computeYChange)
+  try {
+    for (let i = 0; i < deltas.length; i++) {
+      const delta = deltas[i]
+      const marks = []
+      for (const markName in delta.attributes) {
+        marks.push(schema.mark(markName, delta.attributes[markName]))
+      }
+      nodes.push(schema.text(delta.insert, marks))
+    }
+  } catch (e) {
+    // an error occured while creating the node. This is probably a result of a concurrent action.
+    /** @type {Y.Doc} */ (text.doc).transact(transaction => {
+      /** @type {Y.Item} */ (text._item).delete(transaction)
+    }, ySyncPluginKey)
+    return null
+  }
+  // @ts-ignore
+  return nodes
+}
+
+/**
+ * @private
+ * @param {Array<any>} nodes prosemirror node
+ * @param {ProsemirrorMapping} mapping
+ * @return {Y.XmlText}
+ */
+export const createTypeFromTextNodes = (nodes, mapping) => {
+  const type = new Y.XmlText()
+  const delta = nodes.map(node => ({
+    // @ts-ignore
+    insert: node.text,
+    attributes: marksToAttributes(node.marks)
+  }))
+  type.applyDelta(delta)
+  mapping.set(type, nodes)
+  return type
+}
+
+/**
+ * @private
+ * @param {any} node prosemirror node
+ * @param {ProsemirrorMapping} mapping
+ * @return {Y.XmlElement}
+ */
+export const createTypeFromElementNode = (node, mapping) => {
+  const type = new Y.XmlElement(node.type.name)
+  for (const key in node.attrs) {
+    const val = node.attrs[key]
+    if (val !== null && key !== 'ychange') {
+      type.setAttribute(key, val)
+    }
+  }
+  type.insert(0, normalizePNodeContent(node).map(n => createTypeFromTextOrElementNode(n, mapping)))
+  mapping.set(type, node)
+  return type
+}
+
+/**
+ * @private
+ * @param {PModel.Node|Array<PModel.Node>} node prosemirror text node
+ * @param {ProsemirrorMapping} mapping
+ * @return {Y.XmlElement|Y.XmlText}
+ */
+export const createTypeFromTextOrElementNode = (node, mapping) => node instanceof Array ? createTypeFromTextNodes(node, mapping) : createTypeFromElementNode(node, mapping)
+
+const equalAttrs = (pattrs, yattrs) => {
+  const keys = Object.keys(pattrs).filter(key => pattrs[key] !== null)
+  let eq = keys.length === Object.keys(yattrs).filter(key => yattrs[key] !== null).length
+  for (let i = 0; i < keys.length && eq; i++) {
+    const key = keys[i]
+    const l = pattrs[key]
+    const r = yattrs[key]
+    eq = key === 'ychange' || l === r || (typeof l === 'object' && typeof r === 'object' && equalAttrs(l, r))
+  }
+  return eq
+}
+
+/**
+ * @typedef {Array<Array<PModel.Node>|PModel.Node>} NormalizedPNodeContent
+ */
+
+/**
+ * @param {any} pnode
+ * @return {NormalizedPNodeContent}
+ */
+export const normalizePNodeContent = pnode => {
+  const c = pnode.content.content
+  const res = []
+  for (let i = 0; i < c.length; i++) {
+    const n = c[i]
+    if (n.isText) {
+      const textNodes = []
+      for (let tnode = c[i]; i < c.length && tnode.isText; tnode = c[++i]) {
+        textNodes.push(tnode)
+      }
+      i--
+      res.push(textNodes)
+    } else {
+      res.push(n)
+    }
+  }
+  return res
+}
+
+/**
+ * @param {Y.XmlText} ytext
+ * @param {Array<any>} ptexts
+ */
+const equalYTextPText = (ytext, ptexts) => {
+  const delta = ytext.toDelta()
+  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && object.keys(d.attributes || {}).length === ptexts[i].marks.length && ptexts[i].marks.every(mark => equalAttrs(d.attributes[mark.type.name] || {}, mark.attrs)))
+}
+
+/**
+ * @param {Y.XmlElement|Y.XmlText|Y.XmlHook} ytype
+ * @param {any|Array<any>} pnode
+ */
+const equalYTypePNode = (ytype, pnode) => {
+  if (ytype instanceof Y.XmlElement && !(pnode instanceof Array) && matchNodeName(ytype, pnode)) {
+    const normalizedContent = normalizePNodeContent(pnode)
+    return ytype._length === normalizedContent.length && equalAttrs(ytype.getAttributes(), pnode.attrs) && ytype.toArray().every((ychild, i) => equalYTypePNode(ychild, normalizedContent[i]))
+  }
+  return ytype instanceof Y.XmlText && pnode instanceof Array && equalYTextPText(ytype, pnode)
+}
+
+/**
+ * @param {PModel.Node | Array<PModel.Node> | undefined} mapped
+ * @param {PModel.Node | Array<PModel.Node>} pcontent
+ */
+const mappedIdentity = (mapped, pcontent) => mapped === pcontent || (mapped instanceof Array && pcontent instanceof Array && mapped.length === pcontent.length && mapped.every((a, i) => pcontent[i] === a))
+
+/**
+ * @param {Y.XmlElement} ytype
+ * @param {PModel.Node} pnode
+ * @param {ProsemirrorMapping} mapping
+ * @return {{ foundMappedChild: boolean, equalityFactor: number }}
+ */
+const computeChildEqualityFactor = (ytype, pnode, mapping) => {
+  const yChildren = ytype.toArray()
+  const pChildren = normalizePNodeContent(pnode)
+  const pChildCnt = pChildren.length
+  const yChildCnt = yChildren.length
+  const minCnt = math.min(yChildCnt, pChildCnt)
+  let left = 0
+  let right = 0
+  let foundMappedChild = false
+  for (; left < minCnt; left++) {
+    const leftY = yChildren[left]
+    const leftP = pChildren[left]
+    if (mappedIdentity(mapping.get(leftY), leftP)) {
+      foundMappedChild = true// definite (good) match!
+    } else if (!equalYTypePNode(leftY, leftP)) {
+      break
+    }
+  }
+  for (; left + right < minCnt; right++) {
+    const rightY = yChildren[yChildCnt - right - 1]
+    const rightP = pChildren[pChildCnt - right - 1]
+    if (mappedIdentity(mapping.get(rightY), rightP)) {
+      foundMappedChild = true
+    } else if (!equalYTypePNode(rightY, rightP)) {
+      break
+    }
+  }
+  return {
+    equalityFactor: left + right,
+    foundMappedChild
+  }
+}
+
+const ytextTrans = ytext => {
+  let str = ''
+  /**
+   * @type {Y.Item|null}
+   */
+  let n = ytext._start
+  const nAttrs = {}
+  while (n !== null) {
+    if (!n.deleted) {
+      if (n.countable && n.content instanceof Y.ContentString) {
+        str += n.content.str
+      } else if (n.content instanceof Y.ContentFormat) {
+        nAttrs[n.content.key] = null
+      }
+    }
+    n = n.right
+  }
+  return {
+    str,
+    nAttrs
+  }
+}
+
+/**
+ * @todo test this more
+ *
+ * @param {Y.Text} ytext
+ * @param {Array<any>} ptexts
+ * @param {ProsemirrorMapping} mapping
+ */
+const updateYText = (ytext, ptexts, mapping) => {
+  mapping.set(ytext, ptexts)
+  const { nAttrs, str } = ytextTrans(ytext)
+  const content = ptexts.map(p => ({ insert: /** @type {any} */ (p).text, attributes: Object.assign({}, nAttrs, marksToAttributes(p.marks)) }))
+  const { insert, remove, index } = simpleDiff(str, content.map(c => c.insert).join(''))
+  ytext.delete(index, remove)
+  ytext.insert(index, insert)
+  ytext.applyDelta(content.map(c => ({ retain: c.insert.length, attributes: c.attributes })))
+}
+
+const marksToAttributes = marks => {
+  const pattrs = {}
+  marks.forEach(mark => {
+    if (mark.type.name !== 'ychange') {
+      pattrs[mark.type.name] = mark.attrs
+    }
+  })
+  return pattrs
+}
+
+/**
+ * @private
+ * @param {Y.Doc} y
+ * @param {Y.XmlFragment} yDomFragment
+ * @param {any} pNode
+ * @param {ProsemirrorMapping} mapping
+ */
+export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
+  if (yDomFragment instanceof Y.XmlElement && yDomFragment.nodeName !== pNode.type.name) {
+    throw new Error('node name mismatch!')
+  }
+  mapping.set(yDomFragment, pNode)
+  // update attributes
+  if (yDomFragment instanceof Y.XmlElement) {
+    const yDomAttrs = yDomFragment.getAttributes()
+    const pAttrs = pNode.attrs
+    for (const key in pAttrs) {
+      if (pAttrs[key] !== null) {
+        if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
+          yDomFragment.setAttribute(key, pAttrs[key])
+        }
+      } else {
+        yDomFragment.removeAttribute(key)
+      }
+    }
+    // remove all keys that are no longer in pAttrs
+    for (const key in yDomAttrs) {
+      if (pAttrs[key] === undefined) {
+        yDomFragment.removeAttribute(key)
+      }
+    }
+  }
+  // update children
+  const pChildren = normalizePNodeContent(pNode)
+  const pChildCnt = pChildren.length
+  const yChildren = yDomFragment.toArray()
+  const yChildCnt = yChildren.length
+  const minCnt = math.min(pChildCnt, yChildCnt)
+  let left = 0
+  let right = 0
+  // find number of matching elements from left
+  for (; left < minCnt; left++) {
+    const leftY = yChildren[left]
+    const leftP = pChildren[left]
+    if (!mappedIdentity(mapping.get(leftY), leftP)) {
+      if (equalYTypePNode(leftY, leftP)) {
+        // update mapping
+        mapping.set(leftY, leftP)
+      } else {
+        break
+      }
+    }
+  }
+  // find number of matching elements from right
+  for (; right + left + 1 < minCnt; right++) {
+    const rightY = yChildren[yChildCnt - right - 1]
+    const rightP = pChildren[pChildCnt - right - 1]
+    if (!mappedIdentity(mapping.get(rightY), rightP)) {
+      if (equalYTypePNode(rightY, rightP)) {
+        // update mapping
+        mapping.set(rightY, rightP)
+      } else {
+        break
+      }
+    }
+  }
+  y.transact(() => {
+    // try to compare and update
+    while (yChildCnt - left - right > 0 && pChildCnt - left - right > 0) {
+      const leftY = yChildren[left]
+      const leftP = pChildren[left]
+      const rightY = yChildren[yChildCnt - right - 1]
+      const rightP = pChildren[pChildCnt - right - 1]
+      if (leftY instanceof Y.XmlText && leftP instanceof Array) {
+        if (!equalYTextPText(leftY, leftP)) {
+          updateYText(leftY, leftP, mapping)
+        }
+        left += 1
+      } else {
+        let updateLeft = leftY instanceof Y.XmlElement && matchNodeName(leftY, leftP)
+        let updateRight = rightY instanceof Y.XmlElement && matchNodeName(rightY, rightP)
+        if (updateLeft && updateRight) {
+          // decide which which element to update
+          const equalityLeft = computeChildEqualityFactor(/** @type {Y.XmlElement} */(leftY), /** @type {PModel.Node} */(leftP), mapping)
+          const equalityRight = computeChildEqualityFactor(/** @type {Y.XmlElement} */(rightY), /** @type {PModel.Node} */(rightP), mapping)
+          if (equalityLeft.foundMappedChild && !equalityRight.foundMappedChild) {
+            updateRight = false
+          } else if (!equalityLeft.foundMappedChild && equalityRight.foundMappedChild) {
+            updateLeft = false
+          } else if (equalityLeft.equalityFactor < equalityRight.equalityFactor) {
+            updateLeft = false
+          } else {
+            updateRight = false
+          }
+        }
+        if (updateLeft) {
+          updateYFragment(y, /** @type {Y.XmlFragment} */(leftY), /** @type {PModel.Node} */(leftP), mapping)
+          left += 1
+        } else if (updateRight) {
+          updateYFragment(y, /** @type {Y.XmlFragment} */(rightY), /** @type {PModel.Node} */(rightP), mapping)
+          right += 1
+        } else {
+          yDomFragment.delete(left, 1)
+          yDomFragment.insert(left, [createTypeFromTextOrElementNode(leftP, mapping)])
+          left += 1
+        }
+      }
+    }
+    const yDelLen = yChildCnt - left - right
+    if (yDelLen > 0) {
+      yDomFragment.delete(left, yDelLen)
+    }
+    if (left + right < pChildCnt) {
+      const ins = []
+      for (let i = left; i < pChildCnt - right; i++) {
+        ins.push(createTypeFromTextOrElementNode(pChildren[i], mapping))
+      }
+      yDomFragment.insert(left, ins)
+    }
+  }, ySyncPluginKey)
+}
+
+/**
+ * @function
+ * @param {Y.XmlElement} yElement
+ * @param {any} pNode Prosemirror Node
+ */
+const matchNodeName = (yElement, pNode) => !(pNode instanceof Array) && yElement.nodeName === pNode.type.name

--- a/src/lib.js
+++ b/src/lib.js
@@ -253,7 +253,7 @@ export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapsh
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact(transaction => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
-  }, ySyncPluginKey)
+    }, ySyncPluginKey)
     mapping.delete(el)
     return null
   }
@@ -285,7 +285,7 @@ export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSn
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (text.doc).transact(transaction => {
       /** @type {Y.Item} */ (text._item).delete(transaction)
-  }, ySyncPluginKey)
+    }, ySyncPluginKey)
     return null
   }
   // @ts-ignore

--- a/src/lib.js
+++ b/src/lib.js
@@ -493,11 +493,11 @@ const marksToAttributes = marks => {
 }
 
 /**
- * @private
  * @param {Y.Doc} y
  * @param {Y.XmlFragment} yDomFragment
  * @param {any} pNode
  * @param {ProsemirrorMapping} mapping
+ * @return {Y.Doc}
  */
 export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
   if (yDomFragment instanceof Y.XmlElement && yDomFragment.nodeName !== pNode.type.name) {
@@ -612,6 +612,8 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
       yDomFragment.insert(left, ins)
     }
   }, ySyncPluginKey)
+
+  return y
 }
 
 /**

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -4,7 +4,7 @@ import { Decoration, DecorationSet } from 'prosemirror-view' // eslint-disable-l
 import { Plugin, PluginKey } from 'prosemirror-state' // eslint-disable-line
 import { Awareness } from 'y-protocols/awareness.js' // eslint-disable-line
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta } from '../lib.js'
-import { yCursorPluginKey, ySyncPluginKey } from './keys'
+import { yCursorPluginKey, ySyncPluginKey } from './keys.js'
 
 import * as math from 'lib0/math.js'
 
@@ -81,10 +81,10 @@ export const createDecorations = (state, awareness, createCursor) => {
 export const yCursorPlugin = (awareness, { cursorBuilder = defaultCursorBuilder, getSelection = state => state.selection } = {}, cursorStateField = 'cursor') => new Plugin({
   key: yCursorPluginKey,
   state: {
-    init (_, state) {
+    init(_, state) {
       return createDecorations(state, awareness, cursorBuilder)
     },
-    apply (tr, prevState, oldState, newState) {
+    apply(tr, prevState, oldState, newState) {
       const ystate = ySyncPluginKey.getState(newState)
       const yCursorState = tr.getMeta(yCursorPluginKey)
       if ((ystate && ystate.isChangeOrigin) || (yCursorState && yCursorState.awarenessUpdated)) {

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -3,17 +3,10 @@ import * as Y from 'yjs'
 import { Decoration, DecorationSet } from 'prosemirror-view' // eslint-disable-line
 import { Plugin, PluginKey } from 'prosemirror-state' // eslint-disable-line
 import { Awareness } from 'y-protocols/awareness.js' // eslint-disable-line
-import { ySyncPluginKey } from './sync-plugin.js'
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta } from '../lib.js'
+import { yCursorPluginKey, ySyncPluginKey } from './keys'
 
 import * as math from 'lib0/math.js'
-
-/**
- * The unique prosemirror plugin key for cursorPlugin.type
- *
- * @public
- */
-export const yCursorPluginKey = new PluginKey('yjs-cursor')
 
 /**
  * Default generator for a cursor element

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -81,10 +81,10 @@ export const createDecorations = (state, awareness, createCursor) => {
 export const yCursorPlugin = (awareness, { cursorBuilder = defaultCursorBuilder, getSelection = state => state.selection } = {}, cursorStateField = 'cursor') => new Plugin({
   key: yCursorPluginKey,
   state: {
-    init(_, state) {
+    init (_, state) {
       return createDecorations(state, awareness, cursorBuilder)
     },
-    apply(tr, prevState, oldState, newState) {
+    apply (tr, prevState, oldState, newState) {
       const ystate = ySyncPluginKey.getState(newState)
       const yCursorState = tr.getMeta(yCursorPluginKey)
       if ((ystate && ystate.isChangeOrigin) || (yCursorState && yCursorState.awarenessUpdated)) {

--- a/src/plugins/keys.js
+++ b/src/plugins/keys.js
@@ -1,0 +1,23 @@
+
+import { PluginKey } from 'prosemirror-state' // eslint-disable-line
+
+/**
+ * The unique prosemirror plugin key for syncPlugin
+ *
+ * @public
+ */
+export const ySyncPluginKey = new PluginKey('y-sync')
+
+/**
+ * The unique prosemirror plugin key for undoPlugin
+ *
+ * @public
+ */
+export const yUndoPluginKey = new PluginKey('y-undo')
+
+/**
+ * The unique prosemirror plugin key for cursorPlugin
+ *
+ * @public
+ */
+export const yCursorPluginKey = new PluginKey('yjs-cursor')

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -5,34 +5,18 @@
 import { createMutex } from 'lib0/mutex.js'
 import * as PModel from 'prosemirror-model'
 import { Plugin, PluginKey, EditorState, TextSelection } from 'prosemirror-state' // eslint-disable-line
-import * as math from 'lib0/math.js'
-import * as object from 'lib0/object.js'
 import * as set from 'lib0/set.js'
-import { simpleDiff } from 'lib0/diff.js'
-import * as error from 'lib0/error.js'
 import * as Y from 'yjs'
-import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition } from '../lib.js'
+import { ySyncPluginKey } from './keys'
+import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, updateYFragment, createNodeIfNotExists, isVisible } from '../lib.js'
 import * as random from 'lib0/random.js'
 import * as environment from 'lib0/environment.js'
 import * as dom from 'lib0/dom.js'
 
 /**
- * @param {Y.Item} item
- * @param {Y.Snapshot} [snapshot]
- */
-export const isVisible = (item, snapshot) => snapshot === undefined ? !item.deleted : (snapshot.sv.has(item.id.client) && /** @type {number} */ (snapshot.sv.get(item.id.client)) > item.id.clock && !Y.isDeleted(snapshot.ds, item.id))
-
-/**
  * Either a node if type is YXmlElement or an Array of text nodes if YXmlText
  * @typedef {Map<Y.AbstractType, PModel.Node | Array<PModel.Node>>} ProsemirrorMapping
  */
-
-/**
- * The unique prosemirror plugin key for prosemirrorPlugin.
- *
- * @public
- */
-export const ySyncPluginKey = new PluginKey('y-sync')
 
 /**
  * @typedef {Object} ColorDef
@@ -258,7 +242,7 @@ export class ProsemirrorBinding {
   unrenderSnapshot () {
     this.mapping = new Map()
     this.mux(() => {
-      const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */ (t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
+      const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
       // @ts-ignore
       const tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
       tr.setMeta(ySyncPluginKey, { snapshot: null, prevSnapshot: null })
@@ -269,7 +253,7 @@ export class ProsemirrorBinding {
   _forceRerender () {
     this.mapping = new Map()
     this.mux(() => {
-      const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */ (t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
+      const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
       // @ts-ignore
       const tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
       this.prosemirrorView.dispatch(tr)
@@ -294,7 +278,7 @@ export class ProsemirrorBinding {
         const pud = pluginState.permanentUserData
         if (pud) {
           pud.dss.forEach(ds => {
-            Y.iterateDeletedStructs(transaction, ds, item => {})
+            Y.iterateDeletedStructs(transaction, ds, item => { })
           })
         }
         const computeYChange = (type, id) => {
@@ -339,10 +323,10 @@ export class ProsemirrorBinding {
        * @param {Y.AbstractType} type
        */
       const delType = (_, type) => this.mapping.delete(type)
-      Y.iterateDeletedStructs(transaction, transaction.deleteSet, struct => struct.constructor === Y.Item && this.mapping.delete(/** @type {Y.ContentType} */ (/** @type {Y.Item} */ (struct).content).type))
+      Y.iterateDeletedStructs(transaction, transaction.deleteSet, struct => struct.constructor === Y.Item && this.mapping.delete(/** @type {Y.ContentType} */(/** @type {Y.Item} */ (struct).content).type))
       transaction.changed.forEach(delType)
       transaction.changedParentTypes.forEach(delType)
-      const fragmentContent = this.type.toArray().map(t => createNodeIfNotExists(/** @type {Y.XmlElement | Y.XmlHook} */ (t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
+      const fragmentContent = this.type.toArray().map(t => createNodeIfNotExists(/** @type {Y.XmlElement | Y.XmlHook} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
       // @ts-ignore
       let tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
@@ -366,28 +350,6 @@ export class ProsemirrorBinding {
   destroy () {
     this.type.unobserveDeep(this._observeFunction)
   }
-}
-
-/**
- * @private
- * @param {Y.XmlElement | Y.XmlHook} el
- * @param {PModel.Schema} schema
- * @param {ProsemirrorMapping} mapping
- * @param {Y.Snapshot} [snapshot]
- * @param {Y.Snapshot} [prevSnapshot]
- * @param {function('removed' | 'added', Y.ID):any} [computeYChange]
- * @return {PModel.Node | null}
- */
-export const createNodeIfNotExists = (el, schema, mapping, snapshot, prevSnapshot, computeYChange) => {
-  const node = /** @type {PModel.Node} */ (mapping.get(el))
-  if (node === undefined) {
-    if (el instanceof Y.XmlElement) {
-      return createNodeFromYElement(el, schema, mapping, snapshot, prevSnapshot, computeYChange)
-    } else {
-      throw error.methodUnimplemented() // we are currently not handling hooks
-    }
-  }
-  return node
 }
 
 /**
@@ -427,10 +389,10 @@ export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapsh
   try {
     const attrs = el.getAttributes(snapshot)
     if (snapshot !== undefined) {
-      if (!isVisible(/** @type {Y.Item} */ (el._item), snapshot)) {
-        attrs.ychange = computeYChange ? computeYChange('removed', /** @type {Y.Item} */ (el._item).id) : { type: 'removed' }
-      } else if (!isVisible(/** @type {Y.Item} */ (el._item), prevSnapshot)) {
-        attrs.ychange = computeYChange ? computeYChange('added', /** @type {Y.Item} */ (el._item).id) : { type: 'added' }
+      if (!isVisible(/** @type {Y.Item} */(el._item), snapshot)) {
+        attrs.ychange = computeYChange ? computeYChange('removed', /** @type {Y.Item} */(el._item).id) : { type: 'removed' }
+      } else if (!isVisible(/** @type {Y.Item} */(el._item), prevSnapshot)) {
+        attrs.ychange = computeYChange ? computeYChange('added', /** @type {Y.Item} */(el._item).id) : { type: 'added' }
       }
     }
     const node = schema.node(el.nodeName, attrs, children)
@@ -478,332 +440,3 @@ export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSn
   // @ts-ignore
   return nodes
 }
-
-/**
- * @private
- * @param {Array<any>} nodes prosemirror node
- * @param {ProsemirrorMapping} mapping
- * @return {Y.XmlText}
- */
-export const createTypeFromTextNodes = (nodes, mapping) => {
-  const type = new Y.XmlText()
-  const delta = nodes.map(node => ({
-    // @ts-ignore
-    insert: node.text,
-    attributes: marksToAttributes(node.marks)
-  }))
-  type.applyDelta(delta)
-  mapping.set(type, nodes)
-  return type
-}
-
-/**
- * @private
- * @param {any} node prosemirror node
- * @param {ProsemirrorMapping} mapping
- * @return {Y.XmlElement}
- */
-export const createTypeFromElementNode = (node, mapping) => {
-  const type = new Y.XmlElement(node.type.name)
-  for (const key in node.attrs) {
-    const val = node.attrs[key]
-    if (val !== null && key !== 'ychange') {
-      type.setAttribute(key, val)
-    }
-  }
-  type.insert(0, normalizePNodeContent(node).map(n => createTypeFromTextOrElementNode(n, mapping)))
-  mapping.set(type, node)
-  return type
-}
-
-/**
- * @private
- * @param {PModel.Node|Array<PModel.Node>} node prosemirror text node
- * @param {ProsemirrorMapping} mapping
- * @return {Y.XmlElement|Y.XmlText}
- */
-export const createTypeFromTextOrElementNode = (node, mapping) => node instanceof Array ? createTypeFromTextNodes(node, mapping) : createTypeFromElementNode(node, mapping)
-
-const equalAttrs = (pattrs, yattrs) => {
-  const keys = Object.keys(pattrs).filter(key => pattrs[key] !== null)
-  let eq = keys.length === Object.keys(yattrs).filter(key => yattrs[key] !== null).length
-  for (let i = 0; i < keys.length && eq; i++) {
-    const key = keys[i]
-    const l = pattrs[key]
-    const r = yattrs[key]
-    eq = key === 'ychange' || l === r || (typeof l === 'object' && typeof r === 'object' && equalAttrs(l, r))
-  }
-  return eq
-}
-
-/**
- * @typedef {Array<Array<PModel.Node>|PModel.Node>} NormalizedPNodeContent
- */
-
-/**
- * @param {any} pnode
- * @return {NormalizedPNodeContent}
- */
-export const normalizePNodeContent = pnode => {
-  const c = pnode.content.content
-  const res = []
-  for (let i = 0; i < c.length; i++) {
-    const n = c[i]
-    if (n.isText) {
-      const textNodes = []
-      for (let tnode = c[i]; i < c.length && tnode.isText; tnode = c[++i]) {
-        textNodes.push(tnode)
-      }
-      i--
-      res.push(textNodes)
-    } else {
-      res.push(n)
-    }
-  }
-  return res
-}
-
-/**
- * @param {Y.XmlText} ytext
- * @param {Array<any>} ptexts
- */
-const equalYTextPText = (ytext, ptexts) => {
-  const delta = ytext.toDelta()
-  return delta.length === ptexts.length && delta.every((d, i) => d.insert === /** @type {any} */ (ptexts[i]).text && object.keys(d.attributes || {}).length === ptexts[i].marks.length && ptexts[i].marks.every(mark => equalAttrs(d.attributes[mark.type.name] || {}, mark.attrs)))
-}
-
-/**
- * @param {Y.XmlElement|Y.XmlText|Y.XmlHook} ytype
- * @param {any|Array<any>} pnode
- */
-const equalYTypePNode = (ytype, pnode) => {
-  if (ytype instanceof Y.XmlElement && !(pnode instanceof Array) && matchNodeName(ytype, pnode)) {
-    const normalizedContent = normalizePNodeContent(pnode)
-    return ytype._length === normalizedContent.length && equalAttrs(ytype.getAttributes(), pnode.attrs) && ytype.toArray().every((ychild, i) => equalYTypePNode(ychild, normalizedContent[i]))
-  }
-  return ytype instanceof Y.XmlText && pnode instanceof Array && equalYTextPText(ytype, pnode)
-}
-
-/**
- * @param {PModel.Node | Array<PModel.Node> | undefined} mapped
- * @param {PModel.Node | Array<PModel.Node>} pcontent
- */
-const mappedIdentity = (mapped, pcontent) => mapped === pcontent || (mapped instanceof Array && pcontent instanceof Array && mapped.length === pcontent.length && mapped.every((a, i) => pcontent[i] === a))
-
-/**
- * @param {Y.XmlElement} ytype
- * @param {PModel.Node} pnode
- * @param {ProsemirrorMapping} mapping
- * @return {{ foundMappedChild: boolean, equalityFactor: number }}
- */
-const computeChildEqualityFactor = (ytype, pnode, mapping) => {
-  const yChildren = ytype.toArray()
-  const pChildren = normalizePNodeContent(pnode)
-  const pChildCnt = pChildren.length
-  const yChildCnt = yChildren.length
-  const minCnt = math.min(yChildCnt, pChildCnt)
-  let left = 0
-  let right = 0
-  let foundMappedChild = false
-  for (; left < minCnt; left++) {
-    const leftY = yChildren[left]
-    const leftP = pChildren[left]
-    if (mappedIdentity(mapping.get(leftY), leftP)) {
-      foundMappedChild = true// definite (good) match!
-    } else if (!equalYTypePNode(leftY, leftP)) {
-      break
-    }
-  }
-  for (; left + right < minCnt; right++) {
-    const rightY = yChildren[yChildCnt - right - 1]
-    const rightP = pChildren[pChildCnt - right - 1]
-    if (mappedIdentity(mapping.get(rightY), rightP)) {
-      foundMappedChild = true
-    } else if (!equalYTypePNode(rightY, rightP)) {
-      break
-    }
-  }
-  return {
-    equalityFactor: left + right,
-    foundMappedChild
-  }
-}
-
-const ytextTrans = ytext => {
-  let str = ''
-  /**
-   * @type {Y.Item|null}
-   */
-  let n = ytext._start
-  const nAttrs = {}
-  while (n !== null) {
-    if (!n.deleted) {
-      if (n.countable && n.content instanceof Y.ContentString) {
-        str += n.content.str
-      } else if (n.content instanceof Y.ContentFormat) {
-        nAttrs[n.content.key] = null
-      }
-    }
-    n = n.right
-  }
-  return {
-    str,
-    nAttrs
-  }
-}
-
-/**
- * @todo test this more
- *
- * @param {Y.Text} ytext
- * @param {Array<any>} ptexts
- * @param {ProsemirrorMapping} mapping
- */
-const updateYText = (ytext, ptexts, mapping) => {
-  mapping.set(ytext, ptexts)
-  const { nAttrs, str } = ytextTrans(ytext)
-  const content = ptexts.map(p => ({ insert: /** @type {any} */ (p).text, attributes: Object.assign({}, nAttrs, marksToAttributes(p.marks)) }))
-  const { insert, remove, index } = simpleDiff(str, content.map(c => c.insert).join(''))
-  ytext.delete(index, remove)
-  ytext.insert(index, insert)
-  ytext.applyDelta(content.map(c => ({ retain: c.insert.length, attributes: c.attributes })))
-}
-
-const marksToAttributes = marks => {
-  const pattrs = {}
-  marks.forEach(mark => {
-    if (mark.type.name !== 'ychange') {
-      pattrs[mark.type.name] = mark.attrs
-    }
-  })
-  return pattrs
-}
-
-/**
- * @private
- * @param {Y.Doc} y
- * @param {Y.XmlFragment} yDomFragment
- * @param {any} pNode
- * @param {ProsemirrorMapping} mapping
- */
-const updateYFragment = (y, yDomFragment, pNode, mapping) => {
-  if (yDomFragment instanceof Y.XmlElement && yDomFragment.nodeName !== pNode.type.name) {
-    throw new Error('node name mismatch!')
-  }
-  mapping.set(yDomFragment, pNode)
-  // update attributes
-  if (yDomFragment instanceof Y.XmlElement) {
-    const yDomAttrs = yDomFragment.getAttributes()
-    const pAttrs = pNode.attrs
-    for (const key in pAttrs) {
-      if (pAttrs[key] !== null) {
-        if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
-          yDomFragment.setAttribute(key, pAttrs[key])
-        }
-      } else {
-        yDomFragment.removeAttribute(key)
-      }
-    }
-    // remove all keys that are no longer in pAttrs
-    for (const key in yDomAttrs) {
-      if (pAttrs[key] === undefined) {
-        yDomFragment.removeAttribute(key)
-      }
-    }
-  }
-  // update children
-  const pChildren = normalizePNodeContent(pNode)
-  const pChildCnt = pChildren.length
-  const yChildren = yDomFragment.toArray()
-  const yChildCnt = yChildren.length
-  const minCnt = math.min(pChildCnt, yChildCnt)
-  let left = 0
-  let right = 0
-  // find number of matching elements from left
-  for (;left < minCnt; left++) {
-    const leftY = yChildren[left]
-    const leftP = pChildren[left]
-    if (!mappedIdentity(mapping.get(leftY), leftP)) {
-      if (equalYTypePNode(leftY, leftP)) {
-        // update mapping
-        mapping.set(leftY, leftP)
-      } else {
-        break
-      }
-    }
-  }
-  // find number of matching elements from right
-  for (;right + left + 1 < minCnt; right++) {
-    const rightY = yChildren[yChildCnt - right - 1]
-    const rightP = pChildren[pChildCnt - right - 1]
-    if (!mappedIdentity(mapping.get(rightY), rightP)) {
-      if (equalYTypePNode(rightY, rightP)) {
-        // update mapping
-        mapping.set(rightY, rightP)
-      } else {
-        break
-      }
-    }
-  }
-  y.transact(() => {
-    // try to compare and update
-    while (yChildCnt - left - right > 0 && pChildCnt - left - right > 0) {
-      const leftY = yChildren[left]
-      const leftP = pChildren[left]
-      const rightY = yChildren[yChildCnt - right - 1]
-      const rightP = pChildren[pChildCnt - right - 1]
-      if (leftY instanceof Y.XmlText && leftP instanceof Array) {
-        if (!equalYTextPText(leftY, leftP)) {
-          updateYText(leftY, leftP, mapping)
-        }
-        left += 1
-      } else {
-        let updateLeft = leftY instanceof Y.XmlElement && matchNodeName(leftY, leftP)
-        let updateRight = rightY instanceof Y.XmlElement && matchNodeName(rightY, rightP)
-        if (updateLeft && updateRight) {
-          // decide which which element to update
-          const equalityLeft = computeChildEqualityFactor(/** @type {Y.XmlElement} */ (leftY), /** @type {PModel.Node} */ (leftP), mapping)
-          const equalityRight = computeChildEqualityFactor(/** @type {Y.XmlElement} */ (rightY), /** @type {PModel.Node} */ (rightP), mapping)
-          if (equalityLeft.foundMappedChild && !equalityRight.foundMappedChild) {
-            updateRight = false
-          } else if (!equalityLeft.foundMappedChild && equalityRight.foundMappedChild) {
-            updateLeft = false
-          } else if (equalityLeft.equalityFactor < equalityRight.equalityFactor) {
-            updateLeft = false
-          } else {
-            updateRight = false
-          }
-        }
-        if (updateLeft) {
-          updateYFragment(y, /** @type {Y.XmlFragment} */ (leftY), /** @type {PModel.Node} */ (leftP), mapping)
-          left += 1
-        } else if (updateRight) {
-          updateYFragment(y, /** @type {Y.XmlFragment} */ (rightY), /** @type {PModel.Node} */ (rightP), mapping)
-          right += 1
-        } else {
-          yDomFragment.delete(left, 1)
-          yDomFragment.insert(left, [createTypeFromTextOrElementNode(leftP, mapping)])
-          left += 1
-        }
-      }
-    }
-    const yDelLen = yChildCnt - left - right
-    if (yDelLen > 0) {
-      yDomFragment.delete(left, yDelLen)
-    }
-    if (left + right < pChildCnt) {
-      const ins = []
-      for (let i = left; i < pChildCnt - right; i++) {
-        ins.push(createTypeFromTextOrElementNode(pChildren[i], mapping))
-      }
-      yDomFragment.insert(left, ins)
-    }
-  }, ySyncPluginKey)
-}
-
-/**
- * @function
- * @param {Y.XmlElement} yElement
- * @param {any} pNode Prosemirror Node
- */
-const matchNodeName = (yElement, pNode) => !(pNode instanceof Array) && yElement.nodeName === pNode.type.name

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -174,7 +174,7 @@ export class ProsemirrorBinding {
    * @param {Y.XmlFragment} yXmlFragment The bind source
    * @param {any} prosemirrorView The target binding
    */
-  constructor(yXmlFragment, prosemirrorView) {
+  constructor (yXmlFragment, prosemirrorView) {
     this.type = yXmlFragment
     this.prosemirrorView = prosemirrorView
     this.mux = createMutex()
@@ -205,7 +205,7 @@ export class ProsemirrorBinding {
     this._domSelectionInView = null
   }
 
-  _isLocalCursorInView() {
+  _isLocalCursorInView () {
     if (!this.prosemirrorView.hasFocus()) return false
     if (environment.isBrowser && this._domSelectionInView === null) {
       // Calculte the domSelectionInView and clear by next tick after all events are finished
@@ -217,7 +217,7 @@ export class ProsemirrorBinding {
     return this._domSelectionInView
   }
 
-  _isDomSelectionInView() {
+  _isDomSelectionInView () {
     const selection = this.prosemirrorView._root.getSelection()
 
     const range = this.prosemirrorView._root.createRange()
@@ -232,14 +232,14 @@ export class ProsemirrorBinding {
       bounding.top <= (window.innerHeight || documentElement.clientHeight || 0)
   }
 
-  renderSnapshot(snapshot, prevSnapshot) {
+  renderSnapshot (snapshot, prevSnapshot) {
     if (!prevSnapshot) {
       prevSnapshot = Y.createSnapshot(Y.createDeleteSet(), new Map())
     }
     this.prosemirrorView.dispatch(this.prosemirrorView.state.tr.setMeta(ySyncPluginKey, { snapshot, prevSnapshot }))
   }
 
-  unrenderSnapshot() {
+  unrenderSnapshot () {
     this.mapping = new Map()
     this.mux(() => {
       const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
@@ -250,7 +250,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  _forceRerender() {
+  _forceRerender () {
     this.mapping = new Map()
     this.mux(() => {
       const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
@@ -265,7 +265,7 @@ export class ProsemirrorBinding {
    * @param {Y.Snapshot} prevSnapshot
    * @param {Object} pluginState
    */
-  _renderSnapshot(snapshot, prevSnapshot, pluginState) {
+  _renderSnapshot (snapshot, prevSnapshot, pluginState) {
     if (!snapshot) {
       snapshot = Y.snapshot(this.doc)
     }
@@ -310,7 +310,7 @@ export class ProsemirrorBinding {
    * @param {Array<Y.YEvent>} events
    * @param {Y.Transaction} transaction
    */
-  _typeChanged(events, transaction) {
+  _typeChanged (events, transaction) {
     const syncState = ySyncPluginKey.getState(this.prosemirrorView.state)
     if (events.length === 0 || syncState.snapshot != null || syncState.prevSnapshot != null) {
       // drop out if snapshot is active
@@ -338,7 +338,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  _prosemirrorChanged(doc) {
+  _prosemirrorChanged (doc) {
     this.mux(() => {
       this.doc.transact(() => {
         updateYFragment(this.doc, this.type, doc, this.mapping)
@@ -347,7 +347,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  destroy() {
+  destroy () {
     this.type.unobserveDeep(this._observeFunction)
   }
 }
@@ -402,7 +402,7 @@ export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapsh
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact(transaction => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
-  }, ySyncPluginKey)
+    }, ySyncPluginKey)
     mapping.delete(el)
     return null
   }
@@ -434,7 +434,7 @@ export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSn
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (text.doc).transact(transaction => {
       /** @type {Y.Item} */ (text._item).delete(transaction)
-  }, ySyncPluginKey)
+    }, ySyncPluginKey)
     return null
   }
   // @ts-ignore

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -7,7 +7,7 @@ import * as PModel from 'prosemirror-model'
 import { Plugin, PluginKey, EditorState, TextSelection } from 'prosemirror-state' // eslint-disable-line
 import * as set from 'lib0/set.js'
 import * as Y from 'yjs'
-import { ySyncPluginKey } from './keys'
+import { ySyncPluginKey } from './keys.js'
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, updateYFragment, createNodeIfNotExists, isVisible } from '../lib.js'
 import * as random from 'lib0/random.js'
 import * as environment from 'lib0/environment.js'
@@ -174,7 +174,7 @@ export class ProsemirrorBinding {
    * @param {Y.XmlFragment} yXmlFragment The bind source
    * @param {any} prosemirrorView The target binding
    */
-  constructor (yXmlFragment, prosemirrorView) {
+  constructor(yXmlFragment, prosemirrorView) {
     this.type = yXmlFragment
     this.prosemirrorView = prosemirrorView
     this.mux = createMutex()
@@ -205,7 +205,7 @@ export class ProsemirrorBinding {
     this._domSelectionInView = null
   }
 
-  _isLocalCursorInView () {
+  _isLocalCursorInView() {
     if (!this.prosemirrorView.hasFocus()) return false
     if (environment.isBrowser && this._domSelectionInView === null) {
       // Calculte the domSelectionInView and clear by next tick after all events are finished
@@ -217,7 +217,7 @@ export class ProsemirrorBinding {
     return this._domSelectionInView
   }
 
-  _isDomSelectionInView () {
+  _isDomSelectionInView() {
     const selection = this.prosemirrorView._root.getSelection()
 
     const range = this.prosemirrorView._root.createRange()
@@ -232,14 +232,14 @@ export class ProsemirrorBinding {
       bounding.top <= (window.innerHeight || documentElement.clientHeight || 0)
   }
 
-  renderSnapshot (snapshot, prevSnapshot) {
+  renderSnapshot(snapshot, prevSnapshot) {
     if (!prevSnapshot) {
       prevSnapshot = Y.createSnapshot(Y.createDeleteSet(), new Map())
     }
     this.prosemirrorView.dispatch(this.prosemirrorView.state.tr.setMeta(ySyncPluginKey, { snapshot, prevSnapshot }))
   }
 
-  unrenderSnapshot () {
+  unrenderSnapshot() {
     this.mapping = new Map()
     this.mux(() => {
       const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
@@ -250,7 +250,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  _forceRerender () {
+  _forceRerender() {
     this.mapping = new Map()
     this.mux(() => {
       const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */(t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
@@ -265,7 +265,7 @@ export class ProsemirrorBinding {
    * @param {Y.Snapshot} prevSnapshot
    * @param {Object} pluginState
    */
-  _renderSnapshot (snapshot, prevSnapshot, pluginState) {
+  _renderSnapshot(snapshot, prevSnapshot, pluginState) {
     if (!snapshot) {
       snapshot = Y.snapshot(this.doc)
     }
@@ -310,7 +310,7 @@ export class ProsemirrorBinding {
    * @param {Array<Y.YEvent>} events
    * @param {Y.Transaction} transaction
    */
-  _typeChanged (events, transaction) {
+  _typeChanged(events, transaction) {
     const syncState = ySyncPluginKey.getState(this.prosemirrorView.state)
     if (events.length === 0 || syncState.snapshot != null || syncState.prevSnapshot != null) {
       // drop out if snapshot is active
@@ -338,7 +338,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  _prosemirrorChanged (doc) {
+  _prosemirrorChanged(doc) {
     this.mux(() => {
       this.doc.transact(() => {
         updateYFragment(this.doc, this.type, doc, this.mapping)
@@ -347,7 +347,7 @@ export class ProsemirrorBinding {
     })
   }
 
-  destroy () {
+  destroy() {
     this.type.unobserveDeep(this._observeFunction)
   }
 }
@@ -402,7 +402,7 @@ export const createNodeFromYElement = (el, schema, mapping, snapshot, prevSnapsh
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (el.doc).transact(transaction => {
       /** @type {Y.Item} */ (el._item).delete(transaction)
-    }, ySyncPluginKey)
+  }, ySyncPluginKey)
     mapping.delete(el)
     return null
   }
@@ -434,7 +434,7 @@ export const createTextNodesFromYText = (text, schema, mapping, snapshot, prevSn
     // an error occured while creating the node. This is probably a result of a concurrent action.
     /** @type {Y.Doc} */ (text.doc).transact(transaction => {
       /** @type {Y.Item} */ (text._item).delete(transaction)
-    }, ySyncPluginKey)
+  }, ySyncPluginKey)
     return null
   }
   // @ts-ignore

--- a/src/plugins/undo-plugin.js
+++ b/src/plugins/undo-plugin.js
@@ -1,8 +1,9 @@
 
 import { Plugin, PluginKey } from 'prosemirror-state' // eslint-disable-line
 
-import { ySyncPluginKey, getRelativeSelection } from './sync-plugin.js'
+import { getRelativeSelection } from './sync-plugin.js'
 import { UndoManager, Item, ContentType, XmlElement, Text } from 'yjs'
+import { yUndoPluginKey, ySyncPluginKey } from './keys'
 
 export const undo = state => {
   const undoManager = yUndoPluginKey.getState(state).undoManager
@@ -20,8 +21,6 @@ export const redo = state => {
   }
 }
 
-export const yUndoPluginKey = new PluginKey('y-undo')
-
 export const yUndoPlugin = ({ protectedNodes = new Set(['paragraph']), trackedOrigins = [] } = {}) => new Plugin({
   key: yUndoPluginKey,
   state: {
@@ -31,10 +30,10 @@ export const yUndoPlugin = ({ protectedNodes = new Set(['paragraph']), trackedOr
       const undoManager = new UndoManager(ystate.type, {
         trackedOrigins: new Set([ySyncPluginKey].concat(trackedOrigins)),
         deleteFilter: item => !(item instanceof Item) ||
-                              !(item.content instanceof ContentType) ||
-                              !(item.content.type instanceof Text ||
-                              (item.content.type instanceof XmlElement && protectedNodes.has(item.content.type.nodeName))) ||
-                              item.content.type._length === 0
+          !(item.content instanceof ContentType) ||
+          !(item.content.type instanceof Text ||
+            (item.content.type instanceof XmlElement && protectedNodes.has(item.content.type.nodeName))) ||
+          item.content.type._length === 0
       })
       return {
         undoManager,

--- a/src/plugins/undo-plugin.js
+++ b/src/plugins/undo-plugin.js
@@ -3,7 +3,7 @@ import { Plugin, PluginKey } from 'prosemirror-state' // eslint-disable-line
 
 import { getRelativeSelection } from './sync-plugin.js'
 import { UndoManager, Item, ContentType, XmlElement, Text } from 'yjs'
-import { yUndoPluginKey, ySyncPluginKey } from './keys'
+import { yUndoPluginKey, ySyncPluginKey } from './keys.js'
 
 export const undo = state => {
   const undoManager = yUndoPluginKey.getState(state).undoManager

--- a/src/y-prosemirror.js
+++ b/src/y-prosemirror.js
@@ -1,4 +1,6 @@
 export * from './plugins/cursor-plugin.js'
 export * from './plugins/sync-plugin.js'
 export * from './plugins/undo-plugin.js'
+export * from './plugins/keys.js'
+export * from './interface.js'
 export { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta } from './lib.js'


### PR DESCRIPTION
As discussed here: https://discuss.yjs.dev/t/prosemirror-serializer/240

This PR adds new methods to aid getting content into and out of Y.Doc format for Prosemirror users. As part of this I had to move some more generic methods out of the `syncPlugin` and up to the `lib`, I also pulled the plugin keys to a higher level to avoid circular dependencies. 

`yDocToProsemirrorJSON` Is probably not _perfect_ yet, there might be an edge case I haven't covered, but that should become readily apparent in production usage soon.

Edit: I've published a fork with these utilities `@tommoor/y-prosemirror`