### PR TITLE
Fixed event listener memory leak

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -135,6 +135,8 @@ export const yCursorPlugin = (awareness, { cursorBuilder = defaultCursorBuilder,
     return {
       update: updateCursorInfo,
       destroy: () => {
+        view.dom.removeEventListener('focusin', updateCursorInfo)
+        view.dom.removeEventListener('focusout', updateCursorInfo)
         awareness.off('change', awarenessListener)
         awareness.setLocalStateField(cursorStateField, null)
       }


### PR DESCRIPTION
Event listeners should be removed when plugin is destroyed.