### PR TITLE
ShadowRoot.createRange is not a function

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -230,7 +230,7 @@ export class ProsemirrorBinding {
   _isDomSelectionInView () {
     const selection = this.prosemirrorView._root.getSelection()
 
-    const range = this.prosemirrorView._root.createRange()
+    const range = dom.doc.createRange()
     range.setStart(selection.anchorNode, selection.anchorOffset)
     range.setEnd(selection.focusNode, selection.focusOffset)
 


### PR DESCRIPTION
The sync was printing errors in the console when pm was loaded within a web component. This line will not execute the create range function on the document instead of the pm root. The pm root is the document of the shadow root of a web component