### PR TITLE
Clean up yDoc observers on PM plugin destroy

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -202,14 +202,17 @@ export class ProsemirrorBinding {
      * current selection as relative positions in the Yjs model
      */
     this.beforeTransactionSelection = null
-    this.doc.on('beforeAllTransactions', () => {
+    this.beforeAllTransactions = () => {
       if (this.beforeTransactionSelection === null) {
         this.beforeTransactionSelection = getRelativeSelection(this, prosemirrorView.state)
       }
-    })
-    this.doc.on('afterAllTransactions', e => {
+    }
+    this.afterAllTransactions = () => {
       this.beforeTransactionSelection = null
-    })
+    }
+
+    this.doc.on('beforeAllTransactions', this.beforeAllTransactions)
+    this.doc.on('afterAllTransactions', this.afterAllTransactions)
     yXmlFragment.observeDeep(this._observeFunction)
 
     this._domSelectionInView = null
@@ -370,6 +373,8 @@ export class ProsemirrorBinding {
 
   destroy () {
     this.type.unobserveDeep(this._observeFunction)
+    this.doc.off('beforeAllTransactions', this.beforeAllTransactions)
+    this.doc.off('afterAllTransactions', this.afterAllTransactions)
   }
 }
 


### PR DESCRIPTION
I have a few situations where I'd like to keep an already built yDoc in memory (for example, a large one that took a while to parse) and re-use it later. The sync-plugin, however, doesn't seem to expect that behavior, and doesn't clean up the transaction observers on the Prosemirror Plugin destroy hook. This leads to duplicate work and increased processing time on each subsequent re-use.

In this change, I save the transaction hooks as local properties in the ProsemirrorBinding, and remove them in the destroy lifecycle method. 