### PR TITLE
Use `findDiffStart` instead of `equalityDeep`

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -138,7 +138,7 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
         update: () => {
           const pluginState = plugin.getState(view.state)
           if (pluginState.snapshot == null && pluginState.prevSnapshot == null) {
-            if (changedInitialContent || view.state.doc.content.findDiffStart(view.state.doc.type.createAndFill().content) != null) {
+            if (changedInitialContent || view.state.doc.content.findDiffStart(view.state.doc.type.createAndFill().content) !== null) {
               changedInitialContent = true
               binding._prosemirrorChanged(view.state.doc)
             }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -16,7 +16,6 @@ import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition 
 import * as random from 'lib0/random.js'
 import * as environment from 'lib0/environment.js'
 import * as dom from 'lib0/dom.js'
-import * as fun from 'lib0/function.js'
 
 /**
  * @param {Y.Item} item
@@ -139,7 +138,7 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
         update: () => {
           const pluginState = plugin.getState(view.state)
           if (pluginState.snapshot == null && pluginState.prevSnapshot == null) {
-            if (changedInitialContent || !fun.equalityDeep(view.state.doc.type.createAndFill().content.toJSON(), view.state.doc.content.toJSON())) {
+            if (changedInitialContent || view.state.doc.content.findDiffStart(view.state.doc.type.createAndFill().content) != null) {
               changedInitialContent = true
               binding._prosemirrorChanged(view.state.doc)
             }


### PR DESCRIPTION
Use ProseMirror method [`findDiffStart`](https://prosemirror.net/docs/ref/#model.Fragment.findDiffStart) to compare / diff documents instead of converting to JSON and then using lib0's [`equalityDeep`](https://github.com/dmonad/lib0/blob/main/function.js#L78):

```diff
- !fun.equalityDeep(view.state.doc.type.createAndFill().content.toJSON(), view.state.doc.content.toJSON())
+ view.state.doc.content.findDiffStart(view.state.doc.type.createAndFill().content) != null
```

Reasoning is `equalityDeep` fails on two equal JSON objects created by ProseMirror's `toJSON()`, because ProseMirror [uses `Object.empty(null)` to initialize node attrs](https://github.com/ProseMirror/prosemirror-model/search?q=Object.create%28null%29), which results in `equalityDeep` returning false because `Object.create(null).constructor` is undefined (instead of Object as expected). See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create#custom_and_null_objects.

Another work around would be to use

```js
!fun.equalityDeep(
  JSON.parse(JSON.stringify(view.state.doc.type.createAndFill().content.toJSON())), 
  JSON.parse(JSON.stringify(view.state.doc.content.toJSON())),
);
```

which works correctly by converting `Object.create(null)` and forcing it to inherit the `Object.constructor` method. But 
1. we're already working with ProseMirror objects, and 
2. it requires an extra step in `JSON.parse(JSON.stringify(`.