### PR TITLE
add support for overlapping marks

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -267,18 +267,35 @@ export function yDocToProsemirrorJSON (
         }
 
         if (d.attributes) {
-          text.marks = Object.keys(d.attributes).map((type) => {
-            const attrs = d.attributes[type]
-            const mark = {
-              type
-            }
+          let marks = []
+          text.marks = Object.keys(d.attributes).forEach((type) => {
+            let attrs = d.attributes[type]
+            if (Array.isArray(attrs)) {
+              // multiple marks of same type
+              attrs.forEach(singleAttrs => {
+                const mark = {
+                  type
+                }
 
-            if (Object.keys(attrs)) {
-              mark.attrs = attrs
-            }
+                if (Object.keys(singleAttrs)) {
+                  mark.attrs = singleAttrs
+                }
 
-            return mark
+                marks.push(mark)
+              })
+            } else {
+              const mark = {
+                type
+              }
+
+              if (Object.keys(attrs)) {
+                mark.attrs = attrs
+              }
+
+              marks.push(mark)
+            }
           })
+          text.marks = marks
         }
         return text
       })

--- a/test/complexSchema.js
+++ b/test/complexSchema.js
@@ -157,6 +157,7 @@ export const nodes = {
 const emDOM = ['em', 0]
 const strongDOM = ['strong', 0]
 const codeDOM = ['code', 0]
+const commentDOM = ['span', 0]
 
 // :: Object [Specs](#model.MarkSpec) for the marks in the schema.
 export const marks = {
@@ -221,6 +222,16 @@ export const marks = {
     parseDOM: [{ tag: 'code' }],
     toDOM () {
       return codeDOM
+    }
+  },
+  comment: {
+    attrs: {
+      id: { default: null }
+    },
+    exclude: '', // allow multiple "comments" marks to overlap
+    parseDOM: [{ tag: 'span' }],
+    toDOM () {
+      return commentDOM
     }
   },
   ychange: {

--- a/test/y-prosemirror.test.js
+++ b/test/y-prosemirror.test.js
@@ -29,6 +29,36 @@ export const testDocTransformation = tc => {
 /**
  * @param {t.TestCase} tc
  */
+export const testDuplicateMarks = tc => {
+  const ydoc = new Y.Doc()
+  const type = ydoc.getXmlFragment('prosemirror')
+  const view = createNewComplexProsemirrorView(ydoc)
+  t.assert(type.toString() === '', 'should only sync after first change')
+
+  view.dispatch(
+    view.state.tr.setNodeMarkup(0, undefined, {
+      checked: true
+    })
+  )
+
+  const marks = [complexSchema.mark('comment', { id: 0 }), complexSchema.mark('comment', { id: 1 })]
+  view.dispatch(view.state.tr.insert(view.state.doc.content.size - 1, /** @type {any} */ complexSchema.text('hello world', marks)))
+  const stateJSON = view.state.doc.toJSON()
+
+  // test if transforming back and forth from Yjs doc works
+  const backandforth = yDocToProsemirrorJSON(prosemirrorJSONToYDoc(/** @type {any} */ (complexSchema), stateJSON))
+  
+  // TODO: I think the duplicate marks work, but I think this fails because
+  // there is a yChange on stateJSON.content[1] (and not on backandforth)
+  t.compare(stateJSON, backandforth)
+
+  // TODO: create a toString test, this currently fails because YXmlText breaks
+  // t.compareStrings(type.toString(), '<custom checked="true"></custom><paragraph></paragraph>')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
 export const testEmptyNotSync = tc => {
   const ydoc = new Y.Doc()
   const type = ydoc.getXmlFragment('prosemirror')

--- a/test/y-prosemirror.test.js
+++ b/test/y-prosemirror.test.js
@@ -47,7 +47,7 @@ export const testDuplicateMarks = tc => {
 
   // test if transforming back and forth from Yjs doc works
   const backandforth = yDocToProsemirrorJSON(prosemirrorJSONToYDoc(/** @type {any} */ (complexSchema), stateJSON))
-  
+
   // TODO: I think the duplicate marks work, but I think this fails because
   // there is a yChange on stateJSON.content[1] (and not on backandforth)
   t.compare(stateJSON, backandforth)


### PR DESCRIPTION
This addresses issue #34 - while remaining backwards compatible.

There are still two TODO items open open:

- [ ] the test currently fails, I think because there is a yChange attr on one of the documents. I'm not sure what the intention behind yChange is, so I'm not sure what the right way is to fix this
- [ ] the current solution breaks YXmlText.toString because it doesn't handle arrays. I think we should add support for this directly in `yjs`, but want to make sure the solution I'm implementing here is a right approach.