### PR TITLE
Add the ability to customise user cursor selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3201,6 +3201,11 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
+    "tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
   },
   "homepage": "https://github.com/yjs/y-prosemirror#readme",
   "dependencies": {
-    "lib0": "^0.2.34"
+    "lib0": "^0.2.34",
+    "tinycolor2": "^1.4.2"
   },
   "peerDependencies": {
     "yjs": "^13.3.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -78,5 +78,5 @@ export default [{
       mainFields: ['module', 'main']
     })
   ],
-  external: id => /^(lib0|prosemirror|fs|path|jsdom|isomorphic)/.test(id)
+  external: id => /^(lib0|prosemirror|tinycolor2|fs|path|jsdom|isomorphic)/.test(id)
 }]

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -3,6 +3,7 @@ import * as Y from 'yjs'
 import { Decoration, DecorationSet } from 'prosemirror-view' // eslint-disable-line
 import { Plugin } from 'prosemirror-state' // eslint-disable-line
 import { Awareness } from 'y-protocols/awareness.js' // eslint-disable-line
+import color from 'tinycolor2'
 import { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta } from '../lib.js'
 import { yCursorPluginKey, ySyncPluginKey } from './keys.js'
 
@@ -47,6 +48,12 @@ export const createDecorations = (state, awareness, createCursor) => {
       if (user.color == null) {
         user.color = '#ffa500'
       }
+      if (user.selectionAlpha == null) {
+        user.selectionAlpha = 0.44
+      }
+      if (user.selectionColor == null) {
+        user.selectionColor = color(user.color).setAlpha(user.selectionAlpha)
+      }
       if (user.name == null) {
         user.name = `User: ${clientId}`
       }
@@ -59,7 +66,11 @@ export const createDecorations = (state, awareness, createCursor) => {
         decorations.push(Decoration.widget(head, () => createCursor(user), { key: clientId + '', side: 10 }))
         const from = math.min(anchor, head)
         const to = math.max(anchor, head)
-        decorations.push(Decoration.inline(from, to, { style: `background-color: ${user.color}70` }, { inclusiveEnd: true, inclusiveStart: false }))
+        const attrs = {
+          style: `background-color: ${user.selectionColor}`,
+          class: `ProseMirror-yjs-selection`
+        }
+        decorations.push(Decoration.inline(from, to, attrs, { inclusiveEnd: true, inclusiveStart: false }))
       }
     }
   })


### PR DESCRIPTION
* Exposes a class name for CSS styling
* Add the ability to set a custom selection color or a custom alpha

This PR adds `tinycolor2` as a dependency, meaning
* Any color notation can be used - only 6 character Hex codes worked before
* Alpha transparency can be configured, and will work regardless of the color notation used.