### PR TITLE
_root.createRange() errors when used in HTML5 shadow root.

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -232,7 +232,7 @@ export class ProsemirrorBinding {
   _isDomSelectionInView () {
     const selection = this.prosemirrorView._root.getSelection()
 
-    const range = this.prosemirrorView._root.createRange()
+    const range = new Range()
     range.setStart(selection.anchorNode, selection.anchorOffset)
     range.setEnd(selection.focusNode, selection.focusOffset)
 


### PR DESCRIPTION
The `_root.createRange()` on line 235 of sync-plugin.js causes errors when ProseMirror is used within a Shadow Root, because the function does not exist:
`Caught error while handling a Yjs update TypeError: this.prosemirrorView._root.createRange is not a function`

This pull request uses the new `Range()` constructor which does not error.