### PR TITLE
Change Y.XmlElement instanceof check to constructor.name

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -390,7 +390,7 @@ export class ProsemirrorBinding {
 const createNodeIfNotExists = (el, schema, mapping, snapshot, prevSnapshot, computeYChange) => {
   const node = /** @type {PModel.Node} */ (mapping.get(el))
   if (node === undefined) {
-    if (el instanceof Y.XmlElement) {
+    if (el.constructor.name === Y.XmlElement.name) {
       return createNodeFromYElement(el, schema, mapping, snapshot, prevSnapshot, computeYChange)
     } else {
       throw error.methodUnimplemented() // we are currently not handling hooks


### PR DESCRIPTION
In local development, at times you get multiple instances of the same library by npm linking modules
back and forth. Using instanceof with two Yjs libraries loaded fails which would seem unnecessary or at least
should be handled somewhere else.

Related https://discuss.yjs.dev/t/prosemirror-build-variations-and-yjs-shared-cursor/228/3