### PR TITLE
Expose the `mapping` when converting Prosemirror (JSON) to Y.Doc instances

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -193,16 +193,17 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
  *
  * @param {Node} doc
  * @param {string} xmlFragment
+ * @param {ProsemirrorMapping} mapping
  * @return {Y.Doc}
  */
-export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
+export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror', mapping = new Map()) {
   const ydoc = new Y.Doc()
   const type = ydoc.get(xmlFragment, Y.XmlFragment)
   if (!type.doc) {
     return ydoc
   }
 
-  updateYFragment(type.doc, type, doc, new Map())
+  updateYFragment(type.doc, type, doc, mapping)
   return type.doc
 }
 
@@ -216,11 +217,12 @@ export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
  * @param {Schema} schema
  * @param {any} state
  * @param {string} xmlFragment
+ * @param {ProsemirrorMapping} mapping
  * @return {Y.Doc}
  */
-export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror') {
+export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror', mapping = new Map()) {
   const doc = Node.fromJSON(schema, state)
-  return prosemirrorToYDoc(doc, xmlFragment)
+  return prosemirrorToYDoc(doc, xmlFragment, mapping)
 }
 
 /**


### PR DESCRIPTION
This mapping is needed for invoking the position transformation functions, and therefore
shouldn't be thrown away.

---

I added the parameter at the end and made it optional with a default matching the previous behavior, so I claim that this should be quite safe.

Possibly related: 
* https://github.com/yjs/y-prosemirror/issues/56
* https://github.com/yjs/y-prosemirror/pull/64 seems to be focused on the other direction to be more reusable, and may trigger a major version update -- so changing the order of the parameters here could also be done as part of that.