### PR TITLE
Use setMeta for all trs dispatched by ySyncPlugin

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -279,7 +279,7 @@ export class ProsemirrorBinding {
       const fragmentContent = this.type.toArray().map(t => createNodeFromYElement(/** @type {Y.XmlElement} */ (t), this.prosemirrorView.state.schema, this.mapping)).filter(n => n !== null)
       // @ts-ignore
       const tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
-      this.prosemirrorView.dispatch(tr)
+      this.prosemirrorView.dispatch(tr.setMeta(ySyncPluginKey, { isChangeOrigin: true }))
     })
   }
 
@@ -324,7 +324,7 @@ export class ProsemirrorBinding {
         }).filter(n => n !== null)
         // @ts-ignore
         const tr = this.prosemirrorView.state.tr.replace(0, this.prosemirrorView.state.doc.content.size, new PModel.Slice(new PModel.Fragment(fragmentContent), 0, 0))
-        this.prosemirrorView.dispatch(tr)
+        this.prosemirrorView.dispatch(tr.setMeta(ySyncPluginKey, { isChangeOrigin: true }))
       }, ySyncPluginKey)
     })
   }


### PR DESCRIPTION
So this is continuation for #66 and it is the fix I have been using with a locally linked version of `y-prosemirror`. Why I need this is because I'm intercepting transactions as in track changes functionality and I can't really detect whether the transaction was originally from ProseMirror or from ySyncPlugin.

With the added booleans in the meta field I can omit those transaction that are caused by for example rendering a snapshot. Also I think it is better DX if you can immediately see from a transaction that "ah this was dispatched by ySyncPlugin". It doesn't seem there are major downsides, without having the meta payload typed it is I guess a little harder to see what are the passed values.