### PR TITLE
Add support for converting directly between prosemirror and Y.XmlFragment nodes

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -205,8 +205,30 @@ export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
     return ydoc
   }
 
-  updateYFragment(type.doc, type, doc, new Map())
+  prosemirrorToYXmlFragment(doc, type)
   return type.doc
+}
+
+/**
+ * Utility method to update an empty Y.XmlFragment with content from a Prosemirror Doc Node.
+ *
+ * This can be used when importing existing content to Y.Doc for the first time,
+ * note that this should not be used to rehydrate a Y.Doc from a database once
+ * collaboration has begun as all history will be lost
+ *
+ * Note: The Y.XmlFragment does not need to be part of a Y.Doc document at the time that this
+ * method is called, but it must be added before any other operations are performed on it.
+ *
+ * @param {Node} doc prosemirror document.
+ * @param {Y.XmlFragment} [xmlFragment] If supplied, an xml fragment to be
+ *   populated from the prosemirror state; otherwise a new XmlFragment will be created.
+ * @return {Y.XmlFragment}
+ */
+export function prosemirrorToYXmlFragment (doc, xmlFragment) {
+  const type = xmlFragment || new Y.XmlFragment()
+  const ydoc = type.doc ? type.doc : { transact: (transaction) => transaction(undefined) }
+  updateYFragment(ydoc, type, doc, new Map())
+  return type
 }
 
 /**
@@ -227,6 +249,24 @@ export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror
 }
 
 /**
+ * Utility method to convert Prosemirror compatible JSON to a Y.XmlFragment
+ *
+ * This can be used when importing existing content to Y.Doc for the first time,
+ * note that this should not be used to rehydrate a Y.Doc from a database once
+ * collaboration has begun as all history will be lost
+ *
+ * @param {Schema} schema
+ * @param {any} state
+ * @param {Y.XmlFragment} [xmlFragment] If supplied, an xml fragment to be
+ *   populated from the prosemirror state; otherwise a new XmlFragment will be created.
+ * @return {Y.XmlFragment}
+ */
+export function prosemirrorJSONToYXmlFragment (schema, state, xmlFragment) {
+  const doc = Node.fromJSON(schema, state)
+  return prosemirrorToYXmlFragment(doc, xmlFragment)
+}
+
+/**
  * Utility method to convert a Y.Doc to a Prosemirror Doc node.
  *
  * @param {Schema} schema
@@ -235,6 +275,18 @@ export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror
  */
 export function yDocToProsemirror (schema, ydoc) {
   const state = yDocToProsemirrorJSON(ydoc)
+  return Node.fromJSON(schema, state)
+}
+
+/**
+ * Utility method to convert a Y.XmlFragment to a Prosemirror Doc node.
+ *
+ * @param {Schema} schema
+ * @param {Y.XmlFragment} xmlFragment
+ * @return {Node}
+ */
+export function yXmlFragmentToProsemirror (schema, xmlFragment) {
+  const state = yXmlFragmentToProsemirrorJSON(xmlFragment)
   return Node.fromJSON(schema, state)
 }
 
@@ -249,7 +301,17 @@ export function yDocToProsemirrorJSON (
   ydoc,
   xmlFragment = 'prosemirror'
 ) {
-  const items = ydoc.getXmlFragment(xmlFragment).toArray()
+  return yXmlFragmentToProsemirrorJSON(ydoc.getXmlFragment(xmlFragment))
+}
+
+/**
+ * Utility method to convert a Y.Doc to Prosemirror compatible JSON.
+ *
+ * @param {Y.XmlFragment} xmlFragment The fragment, which must be part of a Y.Doc.
+ * @return {Record<string, any>}
+ */
+export function yXmlFragmentToProsemirrorJSON (xmlFragment) {
+  const items = xmlFragment.toArray()
 
   function serialize (item) {
     /**

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -692,7 +692,7 @@ const marksToAttributes = marks => {
 
 /**
  * @private
- * @param {Y.Doc} y
+ * @param {{transact: Function}} y
  * @param {Y.XmlFragment} yDomFragment
  * @param {any} pNode
  * @param {ProsemirrorMapping} mapping

--- a/src/y-prosemirror.js
+++ b/src/y-prosemirror.js
@@ -2,4 +2,5 @@ export * from './plugins/cursor-plugin.js'
 export { ySyncPlugin, isVisible, getRelativeSelection, ProsemirrorBinding } from './plugins/sync-plugin.js'
 export * from './plugins/undo-plugin.js'
 export * from './plugins/keys.js'
-export { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta, prosemirrorJSONToYDoc, yDocToProsemirrorJSON, yDocToProsemirror, prosemirrorToYDoc } from './lib.js'
+export { absolutePositionToRelativePosition, relativePositionToAbsolutePosition, setMeta, prosemirrorJSONToYDoc, yDocToProsemirrorJSON, yDocToProsemirror, prosemirrorToYDoc,
+  prosemirrorJSONToYXmlFragment, yXmlFragmentToProsemirrorJSON, yXmlFragmentToProsemirror, prosemirrorToYXmlFragment } from './lib.js'

--- a/test/y-prosemirror.test.js
+++ b/test/y-prosemirror.test.js
@@ -6,7 +6,7 @@ import * as Y from 'yjs'
 // @ts-ignore
 import { applyRandomTests } from 'yjs/testHelper'
 
-import { ySyncPlugin, prosemirrorJSONToYDoc, yDocToProsemirrorJSON } from '../src/y-prosemirror.js'
+import { ySyncPlugin, prosemirrorJSONToYDoc, yDocToProsemirrorJSON, prosemirrorJSONToYXmlFragment, yXmlFragmentToProsemirrorJSON } from '../src/y-prosemirror.js'
 import { EditorState, TextSelection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import * as basicSchema from 'prosemirror-schema-basic'
@@ -24,6 +24,21 @@ export const testDocTransformation = tc => {
   const stateJSON = view.state.doc.toJSON()
   // test if transforming back and forth from Yjs doc works
   const backandforth = yDocToProsemirrorJSON(prosemirrorJSONToYDoc(/** @type {any} */ (schema), stateJSON))
+  t.compare(stateJSON, backandforth)
+}
+
+export const testXmlFragmentTransformation = tc => {
+  const view = createNewProsemirrorView(new Y.Doc())
+  view.dispatch(view.state.tr.insert(0, /** @type {any} */ (schema.node('paragraph', undefined, schema.text('hello world')))))
+  const stateJSON = view.state.doc.toJSON()
+  console.log(JSON.stringify(stateJSON))
+  // test if transforming back and forth from yXmlFragment works
+  const xml = new Y.XmlFragment()
+  prosemirrorJSONToYXmlFragment(/** @type {any} */ (schema), stateJSON, xml)
+  const doc = new Y.Doc()
+  doc.getMap('root').set('firstDoc', xml)
+  const backandforth = yXmlFragmentToProsemirrorJSON(xml)
+  console.log(JSON.stringify(backandforth))
   t.compare(stateJSON, backandforth)
 }
 


### PR DESCRIPTION
Adds new methods `prosemirrorToYXmlFragment`, `prosemirrorJSONToYXmlFragment`, `yXmlFragmentToProsemirror`, and `yXmlFragmentToProsemirrorJSON` to support direct PM <=> YXmlFragment conversion.

Note there's a small hack in `prosemirrorToYXmlFragment` to allow independent creation of Y.XmlFragment before the Y.Doc exists (supporting bottom-up tree construction)

Fixes #50