### PR TITLE
Exclude the tests from packaging for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "files": [
     "dist/*",
+    "!dist/test.*",
     "src/*"
   ],
   "repository": {


### PR DESCRIPTION
These files are _big_, and completely unneeded when using y-prosemirror.

