### PR TITLE
Clear timeout when destroying plugin

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -75,6 +75,7 @@ const getUserColor = (colorMapping, colors, user) => {
  */
 export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping = new Map(), permanentUserData = null } = {}) => {
   let changedInitialContent = false
+  let rerenderTimeoutId
   const plugin = new Plugin({
     props: {
       editable: (state) => {
@@ -129,8 +130,11 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
     },
     view: view => {
       const binding = new ProsemirrorBinding(yXmlFragment, view)
+      if (rerenderTimeoutId != null) {
+        clearTimeout(rerenderTimeoutId)
+      }
       // Make sure this is called in a separate context
-      setTimeout(() => {
+      rerenderTimeoutId = setTimeout(() => {
         binding._forceRerender()
         view.dispatch(view.state.tr.setMeta(ySyncPluginKey, { binding }))
       }, 0)
@@ -145,6 +149,7 @@ export const ySyncPlugin = (yXmlFragment, { colors = defaultColors, colorMapping
           }
         },
         destroy: () => {
+          clearTimeout(rerenderTimeoutId)
           binding.destroy()
         }
       }


### PR DESCRIPTION
Not clearing the timeout causes issues where code is run after the `EditorView` and its plugins have already been destroyed. In our app this resulted in two errors that manifested in different cases where the editor view was being unmounted:
- `Uncaught TypeError: Cannot read properties of null (reading 'matchesNode')`
- `Uncaught RangeError: Applying a mismatched transaction`

Both errors were fixed by applying the monkey patch kindly provided by @hoebbelsB in #70.

This PR implements that fix in `sync-plugin` so that we could stop monkey patching it.