### PR TITLE
Support passing clientID to doc transformation utils

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -195,11 +195,17 @@ export const relativePositionToAbsolutePosition = (y, documentType, relPos, mapp
  * collaboration has begun as all history will be lost
  *
  * @param {Node} doc
+ * @param {number} clientID
  * @param {string} xmlFragment
  * @return {Y.Doc}
  */
-export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
+export function prosemirrorToYDoc (doc, clientID = null, xmlFragment = 'prosemirror') {
   const ydoc = new Y.Doc()
+  if (clientID) {
+    if (Number.isInteger) ydoc.clientID = clientID
+    else throw Error('clientID must be a valid integer (up to 53 bit)')
+  }
+
   const type = /** @type {Y.XmlFragment} */ (ydoc.get(xmlFragment, Y.XmlFragment))
   if (!type.doc) {
     return ydoc
@@ -218,12 +224,13 @@ export function prosemirrorToYDoc (doc, xmlFragment = 'prosemirror') {
  *
  * @param {Schema} schema
  * @param {any} state
+ * @param {number} clientID
  * @param {string} xmlFragment
  * @return {Y.Doc}
  */
-export function prosemirrorJSONToYDoc (schema, state, xmlFragment = 'prosemirror') {
+export function prosemirrorJSONToYDoc (schema, state, clientID = null, xmlFragment = 'prosemirror') {
   const doc = Node.fromJSON(schema, state)
-  return prosemirrorToYDoc(doc, xmlFragment)
+  return prosemirrorToYDoc(doc, clientID, xmlFragment)
 }
 
 /**

--- a/test/y-prosemirror.test.js
+++ b/test/y-prosemirror.test.js
@@ -7,10 +7,12 @@ import * as Y from 'yjs'
 import { applyRandomTests } from 'yjs/testHelper'
 
 import { ySyncPlugin, prosemirrorJSONToYDoc, yDocToProsemirrorJSON } from '../src/y-prosemirror.js'
+import { prosemirrorToYDoc } from '../src/lib.js'
 import { EditorState, TextSelection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import * as basicSchema from 'prosemirror-schema-basic'
 import { findWrapping } from 'prosemirror-transform'
+import { DOMParser } from 'prosemirror-model'
 import { schema as complexSchema } from './complexSchema.js'
 
 const schema = /** @type {any} */ (basicSchema.schema)
@@ -25,6 +27,24 @@ export const testDocTransformation = tc => {
   // test if transforming back and forth from Yjs doc works
   const backandforth = yDocToProsemirrorJSON(prosemirrorJSONToYDoc(/** @type {any} */ (schema), stateJSON))
   t.compare(stateJSON, backandforth)
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testprosemirrorToYDoc = tc => {
+  const node = document.createElement('p')
+  node.textContent = 'Yjs is awesome'
+  const doc = DOMParser.fromSchema(basicSchema.schema).parse(node)
+
+  const ydocWithRandomClientID = prosemirrorToYDoc(doc)
+  t.assert(ydocWithRandomClientID.clientID !== null, 'ClientID must not be null')
+
+  const existingClientID = 10
+  const ydocWithGlobalClientID = prosemirrorToYDoc(doc, existingClientID)
+  t.assert(ydocWithGlobalClientID.clientID === 10, 'ClientID must be same as existing')
+  const client = ydocWithGlobalClientID.store.clients.get(existingClientID)
+  t.assert(client !== null, 'ClientID must be in the clients Map')
 }
 
 /**


### PR DESCRIPTION
Thanks for this library 🙏 

I have been trying to figure out the initial hydration process especially when the editor content is not saved in `Y.Doc()` format

This PR addresses a missing feature to fully support the template engine approach described here: https://discuss.yjs.dev/t/initial-offline-value-of-a-shared-document/465/13

### After this PR

```javascript
// Server
clientID = userSessionID // (only happens once across a collaboration session)
const contentParser = markdownParser(pmSchema)
const pmDoc = contentParser.parse(markdown)
const ydocTemplate = toBase64(encodeStateAsUpdateV2(prosemirrorToYDoc(pmDoc, clientID)))
```

```javascript
// client
const ydoc = new Y.Doc()
// Loaded server side and passed to DOM
Y.applyUpdateV2(ydoc, fromBase64(ydocTemplate))
ydoc.clientID = userSessionID
```

### Before this PR

The `prosemirrorToYDoc` function uses new `Y.Doc()`, which assigns a random clientID causing a mismatch: 

```javascript
const ydoc = new Y.Doc() // assigns a random clientID in the browser 
Y.applyUpdateV2(ydoc, fromBase64(ydocTemplate)) // random clientID on the server

// => store.clients does not include ydoc.clientID
```