### PR TITLE
add null check for syncState

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -26,7 +26,7 @@ const updateMetas = () => {
   ups.forEach((metas, view) => {
     const tr = view.state.tr
     const syncState = ySyncPluginKey.getState(view.state)
-    if (syncState.binding && !syncState.binding.isDestroyed) {
+    if (syncState && syncState.binding && !syncState.binding.isDestroyed) {
       metas.forEach((val, key) => {
         tr.setMeta(key, val)
       })


### PR DESCRIPTION
Fix:
```
Uncaught TypeError: Cannot read properties of undefined (reading 'binding')
```
when removing the plugins from prosemirror state. It seems that an awareness event from yCursorPlugin is received and processed after the plugins are destroyed.

To reproduce:
```
diff --git a/demo/prosemirror.js b/demo/prosemirror.js
index a1cc530..7712a19 100644
--- a/demo/prosemirror.js
+++ b/demo/prosemirror.js
@@ -18,21 +18,21 @@ window.addEventListener('load', () => {
   editor.setAttribute('id', 'editor')
   const editorContainer = document.createElement('div')
   editorContainer.insertBefore(editor, null)
-  const prosemirrorView = new EditorView(editor, {
-    state: EditorState.create({
-      schema,
-      plugins: [
-        ySyncPlugin(type),
-        yCursorPlugin(provider.awareness),
-        yUndoPlugin(),
-        keymap({
-          'Mod-z': undo,
-          'Mod-y': redo,
-          'Mod-Shift-z': redo
-        })
-      ].concat(exampleSetup({ schema }))
-    })
+  let editorState = EditorState.create({
+    schema,
+    plugins: [
+      ySyncPlugin(type),
+      yCursorPlugin(provider.awareness),
+      yUndoPlugin(),
+      keymap({
+        'Mod-z': undo,
+        'Mod-y': redo,
+        'Mod-Shift-z': redo
+      })
+    ].concat(exampleSetup({ schema }))
   })
+
+  const prosemirrorView = new EditorView(editor, {state: editorState})
   document.body.insertBefore(editorContainer, null)
 
   const connectBtn = /** @type {HTMLElement} */ (document.getElementById('y-connect-btn'))
@@ -40,6 +40,8 @@ window.addEventListener('load', () => {
     if (provider.shouldConnect) {
       provider.disconnect()
       connectBtn.textContent = 'Connect'
+      editorState = editorState.reconfigure({schema, plugins: exampleSetup({ schema })})
+      prosemirrorView.updateState(editorState)
     } else {
       provider.connect()
       connectBtn.textContent = 'Disconnect'
```