### PR TITLE
fix (sync plugin)[Issue #43]: Restore relativeSelection using a NodeSelection if appropriate

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -4,7 +4,7 @@
 
 import { createMutex } from 'lib0/mutex'
 import * as PModel from 'prosemirror-model'
-import { Plugin, TextSelection } from 'prosemirror-state' // eslint-disable-line
+import { Plugin, NodeSelection, TextSelection } from 'prosemirror-state' // eslint-disable-line
 import * as math from 'lib0/math'
 import * as object from 'lib0/object'
 import * as set from 'lib0/set'
@@ -194,14 +194,18 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
     const anchor = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.anchor, binding.mapping)
     const head = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.head, binding.mapping)
     if (anchor !== null && head !== null) {
-      tr = tr.setSelection(TextSelection.create(tr.doc, anchor, head))
+      const selection = relSel.isNodeSelection
+        ? NodeSelection.create(tr.doc, Math.min(anchor, head))
+        : TextSelection.create(tr.doc, anchor, head)
+      tr = tr.setSelection(selection)
     }
   }
 }
 
 export const getRelativeSelection = (pmbinding, state) => ({
   anchor: absolutePositionToRelativePosition(state.selection.anchor, pmbinding.type, pmbinding.mapping),
-  head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping)
+  head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping),
+  isNodeSelection: state.selection instanceof NodeSelection,
 })
 
 /**

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -194,7 +194,7 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
     const anchor = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.anchor, binding.mapping)
     const head = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.head, binding.mapping)
     if (anchor !== null && head !== null) {
-      const selection = relSel.isNodeSelection
+      const selection = relSel.type === 'NodeSelection'
         ? NodeSelection.create(tr.doc, Math.min(anchor, head))
         : TextSelection.create(tr.doc, anchor, head)
       tr = tr.setSelection(selection)
@@ -205,7 +205,10 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
 export const getRelativeSelection = (pmbinding, state) => ({
   anchor: absolutePositionToRelativePosition(state.selection.anchor, pmbinding.type, pmbinding.mapping),
   head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping),
-  isNodeSelection: state.selection instanceof NodeSelection,
+  /**
+   * @type {string} 'NodeSelection' | 'TextSelection' - The type of the selection
+   */
+  type: state.selection instanceof NodeSelection ? 'NodeSelection' : 'TextSelection'
 })
 
 /**

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -194,7 +194,7 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
     const anchor = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.anchor, binding.mapping)
     const head = relativePositionToAbsolutePosition(binding.doc, binding.type, relSel.head, binding.mapping)
     if (anchor !== null && head !== null) {
-      const selection = relSel.type === 'NodeSelection'
+      const selection = relSel.type === 'node'
         ? NodeSelection.create(tr.doc, Math.min(anchor, head))
         : TextSelection.create(tr.doc, anchor, head)
       tr = tr.setSelection(selection)
@@ -206,9 +206,9 @@ export const getRelativeSelection = (pmbinding, state) => ({
   anchor: absolutePositionToRelativePosition(state.selection.anchor, pmbinding.type, pmbinding.mapping),
   head: absolutePositionToRelativePosition(state.selection.head, pmbinding.type, pmbinding.mapping),
   /**
-   * @type {string} 'NodeSelection' | 'TextSelection' - The type of the selection
+   * @type {string} The Prosemirror jsonID of the selection - https://prosemirror.net/docs/ref/#state.Selection^jsonID
    */
-  type: state.selection instanceof NodeSelection ? 'NodeSelection' : 'TextSelection'
+  type: state.selection.jsonID
 })
 
 /**

--- a/test/y-prosemirror.test.js
+++ b/test/y-prosemirror.test.js
@@ -7,7 +7,7 @@ import * as Y from 'yjs'
 import { applyRandomTests } from 'yjs/testHelper'
 
 import { ySyncPlugin, yUndoPlugin, undo, redo, prosemirrorJSONToYDoc, yDocToProsemirrorJSON, prosemirrorJSONToYXmlFragment, yXmlFragmentToProsemirrorJSON } from '../src/y-prosemirror.js'
-import { EditorState, TextSelection } from 'prosemirror-state'
+import { EditorState, NodeSelection, TextSelection } from 'prosemirror-state'
 import { EditorView } from 'prosemirror-view'
 import * as basicSchema from 'prosemirror-schema-basic'
 import { findWrapping } from 'prosemirror-transform'
@@ -70,6 +70,22 @@ export const testEmptyParagraph = tc => {
   t.assert(yxml.length === 2 && yxml.get(0).length === 1, 'contains one paragraph containing a ytext')
   view.dispatch(view.state.tr.delete(1, 4)) // delete characters 123
   t.assert(yxml.length === 2 && yxml.get(0).length === 1, 'doesn\'t delete the ytext')
+}
+
+/**
+ * @param {t.TestCase} tc
+ */
+export const testRestoreRelativePositionRetainsNodeSelection = tc => {
+  const ydoc = new Y.Doc()
+  const view = createNewProsemirrorView(ydoc)
+  view.dispatch(view.state.tr.insert(0, /** @type {any} */ (schema.node('image', { src: '/cool-img' }))))
+  view.dispatch(view.state.tr.setSelection(NodeSelection.create(view.state.doc, 1)))
+  t.assert(view.state.selection instanceof NodeSelection, 'node selection exists')
+
+  view.dispatch(view.state.tr.insert(0, /** @type {any} */ (schema.node('paragraph', undefined, schema.text('123')))))
+  const yxml = ydoc.get('prosemirror')
+  t.assert(yxml.length === 3 && yxml.get(0).length === 1, 'contains one paragraph and one image')
+  t.assert(view.state.selection instanceof NodeSelection, 'node selection is retained')
 }
 
 export const testAddToHistory = tc => {


### PR DESCRIPTION
## Changes

- Update `getRelativeSelection` to capture whether or not the current selection is a NodeSelection
- Update `restoreRelativeSelection` to use a node selection if restoring one


## Context

Attempts to fix #43 