### PR TITLE
skip unnecessary full-document replaces

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -375,11 +375,14 @@ export class ProsemirrorBinding {
           this.mapping
         )
       ).filter((n) => n !== null)
-      // @ts-ignore
+      const fragment = PModel.Fragment.from(fragmentContent)
+      if (this.prosemirrorView.state.doc.content.eq(fragment)) {
+        return
+      }
       const tr = this._tr.replace(
         0,
         this.prosemirrorView.state.doc.content.size,
-        new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
+        new PModel.Slice(fragment, 0, 0)
       )
       tr.setMeta(ySyncPluginKey, { snapshot: null, prevSnapshot: null })
       this.prosemirrorView.dispatch(tr)
@@ -396,11 +399,14 @@ export class ProsemirrorBinding {
           this.mapping
         )
       ).filter((n) => n !== null)
-      // @ts-ignore
+      const fragment = PModel.Fragment.from(fragmentContent)
+      if (this.prosemirrorView.state.doc.content.eq(fragment)) {
+        return
+      }      
       const tr = this._tr.replace(
         0,
         this.prosemirrorView.state.doc.content.size,
-        new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
+        new PModel.Slice(fragment, 0, 0)
       )
       this.prosemirrorView.dispatch(
         tr.setMeta(ySyncPluginKey, { isChangeOrigin: true })
@@ -470,11 +476,14 @@ export class ProsemirrorBinding {
             return null
           }
         }).filter((n) => n !== null)
-        // @ts-ignore
+        const fragment = PModel.Fragment.from(fragmentContent)
+        if (this.prosemirrorView.state.doc.content.eq(fragment)) {
+          return
+        }        
         const tr = this._tr.replace(
           0,
           this.prosemirrorView.state.doc.content.size,
-          new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
+          new PModel.Slice(fragment, 0, 0)
         )
         this.prosemirrorView.dispatch(
           tr.setMeta(ySyncPluginKey, { isChangeOrigin: true })
@@ -522,11 +531,14 @@ export class ProsemirrorBinding {
           this.mapping
         )
       ).filter((n) => n !== null)
-      // @ts-ignore
+      const fragment = PModel.Fragment.from(fragmentContent)
+      if (this.prosemirrorView.state.doc.content.eq(fragment)) {
+        return
+      }      
       let tr = this._tr.replace(
         0,
         this.prosemirrorView.state.doc.content.size,
-        new PModel.Slice(PModel.Fragment.from(fragmentContent), 0, 0)
+        new PModel.Slice(fragment, 0, 0)
       )
       restoreRelativeSelection(tr, this.beforeTransactionSelection, this)
       tr = tr.setMeta(ySyncPluginKey, { isChangeOrigin: true })


### PR DESCRIPTION
This PR skips some unnecessary replaces by comparing the incoming content and current content in the ProseMirror editor view. This could be a potential solution for https://github.com/yjs/y-prosemirror/issues/126