### PR TITLE
move typescript to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.42",
-        "typescript": "^4.8.4"
+        "lib0": "^0.2.42"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.1",
@@ -26,6 +25,7 @@
         "prosemirror-view": "^1.26.2",
         "rollup": "^2.59.0",
         "standard": "^17.0.0",
+        "typescript": "^4.8.4",
         "y-protocols": "^1.0.5",
         "y-webrtc": "^10.2.0",
         "yjs": "^13.5.38"
@@ -4847,6 +4847,7 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8905,7 +8906,8 @@
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,7 @@
   },
   "homepage": "https://github.com/yjs/y-prosemirror#readme",
   "dependencies": {
-    "lib0": "^0.2.42",
-    "typescript": "^4.8.4"
+    "lib0": "^0.2.42"
   },
   "peerDependencies": {
     "prosemirror-model": "^1.7.1",
@@ -76,6 +75,7 @@
     "prosemirror-view": "^1.26.2",
     "rollup": "^2.59.0",
     "standard": "^17.0.0",
+    "typescript": "^4.8.4",
     "y-protocols": "^1.0.5",
     "y-webrtc": "^10.2.0",
     "yjs": "^13.5.38"


### PR DESCRIPTION
`y-prosemirror` doesn't depend on `typescript` during runtime, so I guess `typescript` should be moved to `devDependencies`. 