### PR TITLE
Allow skipping YDoc updates for transactions

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -113,6 +113,7 @@ export const ySyncPlugin = (yXmlFragment, {
           isChangeOrigin: false,
           isUndoRedoOperation: false,
           addToHistory: true,
+          addToYDoc: true,
           colors,
           colorMapping,
           permanentUserData
@@ -127,6 +128,7 @@ export const ySyncPlugin = (yXmlFragment, {
           }
         }
         pluginState.addToHistory = tr.getMeta('addToHistory') !== false
+        pluginState.addToYDoc = tr.getMeta('addToYDoc') !== false
         // always set isChangeOrigin. If undefined, this is not change origin.
         pluginState.isChangeOrigin = change !== undefined &&
           !!change.isChangeOrigin
@@ -208,12 +210,15 @@ export const ySyncPlugin = (yXmlFragment, {
                   um.stopCapturing()
                 }
               }
-              binding.mux(() => {
-                /** @type {Y.Doc} */ (pluginState.doc).transact((tr) => {
-                  tr.meta.set('addToHistory', pluginState.addToHistory)
-                  binding._prosemirrorChanged(view.state.doc)
-                }, ySyncPluginKey)
-              })
+
+              if (pluginState.addToYDoc) {
+                binding.mux(() => {
+                  /** @type {Y.Doc} */ (pluginState.doc).transact((tr) => {
+                    tr.meta.set('addToHistory', pluginState.addToHistory)
+                    binding._prosemirrorChanged(view.state.doc)
+                  }, ySyncPluginKey)
+                })
+              }
             }
           }
         },


### PR DESCRIPTION
YJS integration with our editor encountered a problem. We have some PM nodes & marks that are per-session. We do not want to update other sessions about their existence and changes when they are in the doc. 

- Some of them states that the user is in a middle of an "inner" session, and usually there's a floating card displayed when they are on the screen. 
- The other are kind of a "dictionary" marks. We don't want the other session to receive the same mark, even if it sound like we should on the first glance, since other parts of our editor screen won't be synced with it, which is problematic for our users. 

We just used `addToHistory` flag until we added YJS. It worked great :) 
The change is basically a very small one. We added a state param called `addToYDoc` that is true by default, and false only when a user passes `addToYDoc` in the transaction meta. When it's false, the change won't be reflected in the doc history, so we won't update other sessions about the redundant change.