### PR TITLE
Fix to load type definition in esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "exports": {
     ".": {
+      "types": "./dist/src/y-prosemirror.d.ts",
       "import": "./src/y-prosemirror.js",
       "require": "./dist/y-prosemirror.cjs"
     }


### PR DESCRIPTION
I'm trying to y-prosemirror with TypeScript `moduleResolution: "Bundler"` mode.
But TypeScript can not find y-prosemirror type definition in this mode.

To import the types correctly, we need to add `exports.types` field.
https://www.typescriptlang.org/docs/handbook/esm-node.html