### PR TITLE
feat: Added `awarenessStateFilter` option for filtering `awareness.getState()`

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -12,6 +12,16 @@ import { yCursorPluginKey, ySyncPluginKey } from './keys.js'
 import * as math from 'lib0/math'
 
 /**
+ * Default awareness state filter
+ *
+ * @param {number} currentClientId current client id
+ * @param {number} userClientId user client id
+ * @param {any} user user data
+ * @return {boolean}
+ */
+export const defaultAwarenessStateFilter = (currentClientId, userClientId, user) => currentClientId !== userClientId;
+
+/**
  * Default generator for a cursor element
  *
  * @param {any} user user data
@@ -50,6 +60,7 @@ const rxValidColor = /^#[0-9a-fA-F]{6}$/
 /**
  * @param {any} state
  * @param {Awareness} awareness
+ * @param {function(number, number, any):boolean} awarenessFilter
  * @param {function({ name: string, color: string }):Element} createCursor
  * @param {function({ name: string, color: string }):import('prosemirror-view').DecorationAttrs} createSelection
  * @return {any} DecorationSet
@@ -57,6 +68,7 @@ const rxValidColor = /^#[0-9a-fA-F]{6}$/
 export const createDecorations = (
   state,
   awareness,
+  awarenessFilter,
   createCursor,
   createSelection
 ) => {
@@ -71,9 +83,10 @@ export const createDecorations = (
     return DecorationSet.create(state.doc, [])
   }
   awareness.getStates().forEach((aw, clientId) => {
-    if (clientId === y.clientID) {
+    if (!awarenessFilter(y.clientID, clientId, aw)) {
       return
     }
+
     if (aw.cursor != null) {
       const user = aw.user || {}
       if (user.color == null) {
@@ -128,6 +141,7 @@ export const createDecorations = (
  * @public
  * @param {Awareness} awareness
  * @param {object} opts
+ * @param {function(any, any, any):boolean} [opts.awarenessStateFilter]
  * @param {function(any):HTMLElement} [opts.cursorBuilder]
  * @param {function(any):import('prosemirror-view').DecorationAttrs} [opts.selectionBuilder]
  * @param {function(any):any} [opts.getSelection]
@@ -137,6 +151,7 @@ export const createDecorations = (
 export const yCursorPlugin = (
   awareness,
   {
+    awarenessStateFilter = defaultAwarenessStateFilter,
     cursorBuilder = defaultCursorBuilder,
     selectionBuilder = defaultSelectionBuilder,
     getSelection = (state) => state.selection
@@ -150,6 +165,7 @@ export const yCursorPlugin = (
         return createDecorations(
           state,
           awareness,
+          awarenessStateFilter,
           cursorBuilder,
           selectionBuilder
         )
@@ -164,6 +180,7 @@ export const yCursorPlugin = (
           return createDecorations(
             newState,
             awareness,
+            awarenessStateFilter,
             cursorBuilder,
             selectionBuilder
           )


### PR DESCRIPTION
This option is needed when we want to remove self "cursor" when opened N-tabs or other logic.

For example, in "GoogleDocs", this is exactly the behavior, they display N-1 "cursors" (N — number of tabs), but in the case of "Notion", they do not display their own "cursor".

```js
yCursorPlugin(provider.awareness, {
  awarenessStateFilter: (_, __, user) => user.id !== getAuthUserId(),
})
```