### PR TITLE
Inspect meta of `appendedTransaction` for possible `addToHistory:false

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -126,7 +126,8 @@ export const ySyncPlugin = (yXmlFragment, {
             pluginState[key] = change[key]
           }
         }
-        pluginState.addToHistory = tr.getMeta('addToHistory') !== false
+        const appended = tr.getMeta('appendedTransaction')
+        pluginState.addToHistory = tr.getMeta('addToHistory') !== false && !(appended && appended.getMeta('addToHistory') === false)
         // always set isChangeOrigin. If undefined, this is not change origin.
         pluginState.isChangeOrigin = change !== undefined &&
           !!change.isChangeOrigin


### PR DESCRIPTION
Resolves #141.

Using the same approach as in native `prosemirror-history`, added inspection of `appendedTransaction` meta for possible `addToHistory: false` to prevent root transaction from appearing on the undo/redo stack.

Added a test case that covers expected behavior.