### PR TITLE
sync-plugin: make `y-prosemirror` not building against new `yjs`.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "typescript": "^4.8.4",
         "y-protocols": "^1.0.5",
         "y-webrtc": "^10.2.0",
-        "yjs": "^13.5.38"
+        "yjs": "^13.5.45"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -39,7 +39,7 @@
         "prosemirror-state": "^1.2.3",
         "prosemirror-view": "^1.9.10",
         "y-protocols": "^1.0.1",
-        "yjs": "^13.5.38"
+        "yjs": "^13.5.45"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -2995,14 +2995,18 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.52",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.52.tgz",
-      "integrity": "sha512-CjxlM7UgICfN6b2OPALBXchIBiNk6jE+1g7JP8ha+dh1xKRDSYpH0WQl1+rMqCju49xUnwPG34v4CR5/rPOZhg==",
+      "version": "0.2.86",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.86.tgz",
+      "integrity": "sha512-kxigQTM4Q7NwJkEgdqQvU21qiR37twcqqLmh+/SbiGbRLfPlLVbHyY9sWp7PwXh0Xus9ELDSjsUOwcrdt5yZ4w==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
+      "bin": {
+        "0gentesthtml": "bin/gentesthtml.js",
+        "0serve": "bin/0serve.js"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -5291,12 +5295,16 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.5.41",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.41.tgz",
-      "integrity": "sha512-4eSTrrs8OeI0heXKKioRY4ag7V5Bk85Z4MeniUyown3o3y0G7G4JpAZWrZWfTp7pzw2b53GkAQWKqHsHi9j9JA==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
       "dev": true,
       "dependencies": {
-        "lib0": "^0.2.49"
+        "lib0": "^0.2.74"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -7511,9 +7519,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.52",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.52.tgz",
-      "integrity": "sha512-CjxlM7UgICfN6b2OPALBXchIBiNk6jE+1g7JP8ha+dh1xKRDSYpH0WQl1+rMqCju49xUnwPG34v4CR5/rPOZhg==",
+      "version": "0.2.86",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.86.tgz",
+      "integrity": "sha512-kxigQTM4Q7NwJkEgdqQvU21qiR37twcqqLmh+/SbiGbRLfPlLVbHyY9sWp7PwXh0Xus9ELDSjsUOwcrdt5yZ4w==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -9257,12 +9265,12 @@
       }
     },
     "yjs": {
-      "version": "13.5.41",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.5.41.tgz",
-      "integrity": "sha512-4eSTrrs8OeI0heXKKioRY4ag7V5Bk85Z4MeniUyown3o3y0G7G4JpAZWrZWfTp7pzw2b53GkAQWKqHsHi9j9JA==",
+      "version": "13.6.8",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.8.tgz",
+      "integrity": "sha512-ZPq0hpJQb6f59B++Ngg4cKexDJTvfOgeiv0sBc4sUm8CaBWH7OQC4kcCgrqbjJ/B2+6vO49exvTmYfdlPtcjbg==",
       "dev": true,
       "requires": {
-        "lib0": "^0.2.49"
+        "lib0": "^0.2.74"
       }
     },
     "yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "prosemirror-state": "^1.2.3",
     "prosemirror-view": "^1.9.10",
     "y-protocols": "^1.0.1",
-    "yjs": "^13.5.38"
+    "yjs": "^13.5.45"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.1",
@@ -78,6 +78,6 @@
     "typescript": "^4.8.4",
     "y-protocols": "^1.0.5",
     "y-webrtc": "^10.2.0",
-    "yjs": "^13.5.38"
+    "yjs": "^13.5.45"
   }
 }

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -659,7 +659,7 @@ const createNodeFromYElement = (
       .forEach(createChildren)
   }
   try {
-    const attrs = el.getAttributes(snapshot)
+    const attrs = el.getAttributes()
     if (snapshot !== undefined) {
       if (!isVisible(/** @type {Y.Item} */ (el._item), snapshot)) {
         attrs.ychange = computeYChange


### PR DESCRIPTION
**Issue:**
Currently, `y-prosemirror` does not build against `yjs` newer (or equal) than `v13.5.45`, it `npm run dist` throws:
```
src/plugins/sync-plugin.js:662:36 - error TS2554: Expected 0 arguments, but got 1.

662     const attrs = el.getAttributes(snapshot)
                                       ~~~~~~~~
Found 1 error in src/plugins/sync-plugin.js:662
```

**Cause:**
The `el.getAttributes(snapshot)` was changed to `el.getAttributes()`, (the implementation did not use the snapshot arg anyway) here (if I am `git blaming` correctly :-) )
https://github.com/yjs/yjs/compare/v13.5.44...v13.5.45#diff-c299d1b6aeba1b81704fa26fd317da05091111fc72ac264c0772d2563ed9f6f8L1237

**Fix:**
- rm the arg as well to support newer yjs
- bump up to the lowest `yjs` version with the arg removed