### PR TITLE
Export `updateYFragment`

### DIFF
--- a/src/y-prosemirror.js
+++ b/src/y-prosemirror.js
@@ -1,5 +1,5 @@
 export * from './plugins/cursor-plugin.js'
-export { ySyncPlugin, isVisible, getRelativeSelection, ProsemirrorBinding } from './plugins/sync-plugin.js'
+export { ySyncPlugin, isVisible, getRelativeSelection, ProsemirrorBinding, updateYFragment } from './plugins/sync-plugin.js'
 export * from './plugins/undo-plugin.js'
 export * from './plugins/keys.js'
 export {


### PR DESCRIPTION
# What this does
- exports `updateYFragment`

# Why?
- This allows using `updateYFragment` outside of the context of the plugin

# But why?
My usecase is to allow a server to apply prosemirror transactions to a yDoc by using prosemirror transactions, instead of yJS transactions. I do this by:
1. Obtain a direct connection to the `yDoc` from the server
2. Derive the `pmDoc` from the `yDoc` using the existing utilities
3. Creating my transactions (`tr.doThing()`)
4. I cannot (and don't need to) `dispatch(tr)`, because I never mount the prosemirror view, therefore I just get the resulting document with the modifications applied by reading from `tr.doc`
5. call `updateYFragment`

This results in code like this (I'm using tiptap/hocuspocus):
```typescript
const docConnection = await hocusPocusServer.openDirectConnection("my-document", {});

await docConnection.transact((yDoc) => {
  const pmDocJSON = TiptapTransformer.fromYdoc(yDoc, "default");
  const docNode = schema.nodeFromJSON(pmDocJSON);
  const editorState = EditorState.create({ schema, doc: docNode });
  const { tr } = editorState;

  tr.doThing();
  tr.doThing2();
  tr.doThing3();

  const yDocNode = yDoc.getXmlFragment("default");
  updateYFragment(yDoc, yDocNode, tr.doc, new Map());
})
```