### PR TITLE
Removed reference to travis in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# y-prosemirror [![Build Status](https://travis-ci.com/yjs/y-prosemirror.svg?branch=master)](https://travis-ci.com/yjs/y-prosemirror)
+# y-prosemirror
 
 > [ProseMirror](http://prosemirror.net/) Binding for [Yjs](https://github.com/yjs/yjs) - [Demo](https://demos.yjs.dev/prosemirror/prosemirror.html)
 


### PR DESCRIPTION
Version 1.0.17 removed .travis.yml and now the build status is broken.
If travis is reimplemented then the link is to https://app.travis-ci.com/github/yjs/y-prosemirror