### PR TITLE
Fix `cursorStateField` bug

### DIFF
--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -186,7 +186,8 @@ export const yCursorPlugin = (
             awareness,
             awarenessStateFilter,
             cursorBuilder,
-            selectionBuilder
+            selectionBuilder,
+            cursorStateField
           )
         }
         return prevState.map(tr.mapping, tr.doc)

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -87,7 +87,6 @@ export const createDecorations = (
   awareness.getStates().forEach((aw, clientId) => {
     if (!awarenessFilter(y.clientID, clientId, aw)) {
       return
-      return;
     }
 
     if (aw[cursorStateField] != null) {

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -63,6 +63,7 @@ const rxValidColor = /^#[0-9a-fA-F]{6}$/
  * @param {function(number, number, any):boolean} awarenessFilter
  * @param {function({ name: string, color: string }):Element} createCursor
  * @param {function({ name: string, color: string }):import('prosemirror-view').DecorationAttrs} createSelection
+ * @param {string} cursorStateField
  * @return {any} DecorationSet
  */
 export const createDecorations = (
@@ -70,7 +71,8 @@ export const createDecorations = (
   awareness,
   awarenessFilter,
   createCursor,
-  createSelection
+  createSelection,
+  cursorStateField
 ) => {
   const ystate = ySyncPluginKey.getState(state)
   const y = ystate.doc
@@ -85,10 +87,11 @@ export const createDecorations = (
   awareness.getStates().forEach((aw, clientId) => {
     if (!awarenessFilter(y.clientID, clientId, aw)) {
       return
+      return;
     }
 
-    if (aw.cursor != null) {
-      const user = aw.user || {}
+    if (aw[cursorStateField] != null) {
+      const user = aw.user || {};
       if (user.color == null) {
         user.color = '#ffa500'
       } else if (!rxValidColor.test(user.color)) {
@@ -101,13 +104,13 @@ export const createDecorations = (
       let anchor = relativePositionToAbsolutePosition(
         y,
         ystate.type,
-        Y.createRelativePositionFromJSON(aw.cursor.anchor),
+        Y.createRelativePositionFromJSON(aw[cursorStateField].anchor),
         ystate.binding.mapping
-      )
+      );
       let head = relativePositionToAbsolutePosition(
         y,
         ystate.type,
-        Y.createRelativePositionFromJSON(aw.cursor.head),
+        Y.createRelativePositionFromJSON(aw[cursorStateField].head),
         ystate.binding.mapping
       )
       if (anchor !== null && head !== null) {
@@ -167,7 +170,8 @@ export const yCursorPlugin = (
           awareness,
           awarenessStateFilter,
           cursorBuilder,
-          selectionBuilder
+          selectionBuilder,
+          cursorStateField
         )
       },
       apply (tr, prevState, _oldState, newState) {

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -90,7 +90,7 @@ export const createDecorations = (
     }
 
     if (aw[cursorStateField] != null) {
-      const user = aw.user || {};
+      const user = aw.user || {}
       if (user.color == null) {
         user.color = '#ffa500'
       } else if (!rxValidColor.test(user.color)) {
@@ -105,7 +105,7 @@ export const createDecorations = (
         ystate.type,
         Y.createRelativePositionFromJSON(aw[cursorStateField].anchor),
         ystate.binding.mapping
-      );
+      )
       let head = relativePositionToAbsolutePosition(
         y,
         ystate.type,
@@ -246,13 +246,7 @@ export const yCursorPlugin = (
             })
           }
         } else if (
-          current[cursorStateField] != null &&
-          relativePositionToAbsolutePosition(
-            ystate.doc,
-            ystate.type,
-            Y.createRelativePositionFromJSON(current[cursorStateField].anchor),
-            ystate.binding.mapping
-          ) !== null
+          current[cursorStateField] != null
         ) {
           // delete cursor information if current cursor information is owned by this editor binding
           awareness.setLocalStateField(cursorStateField, null)

--- a/src/plugins/cursor-plugin.js
+++ b/src/plugins/cursor-plugin.js
@@ -231,13 +231,13 @@ export const yCursorPlugin = (
             ystate.binding.mapping
           )
           if (
-            current.cursor == null ||
+            current[cursorStateField] == null ||
             !Y.compareRelativePositions(
-              Y.createRelativePositionFromJSON(current.cursor.anchor),
+              Y.createRelativePositionFromJSON(current[cursorStateField].anchor),
               anchor
             ) ||
             !Y.compareRelativePositions(
-              Y.createRelativePositionFromJSON(current.cursor.head),
+              Y.createRelativePositionFromJSON(current[cursorStateField].head),
               head
             )
           ) {
@@ -247,11 +247,11 @@ export const yCursorPlugin = (
             })
           }
         } else if (
-          current.cursor != null &&
+          current[cursorStateField] != null &&
           relativePositionToAbsolutePosition(
             ystate.doc,
             ystate.type,
-            Y.createRelativePositionFromJSON(current.cursor.anchor),
+            Y.createRelativePositionFromJSON(current[cursorStateField].anchor),
             ystate.binding.mapping
           ) !== null
         ) {


### PR DESCRIPTION
# Summary
This PR fixes a long-standing issue with the `cursorStateField` param that’s passed into `yCursorPlugin`.

Setting `cursorStateField` is the only way to namespace awareness state so that cursors from different subdocuments syncing over the same provider will be able to read and write their own cursor state.

However, it is currently broken. Setting `cursorStateField` doesn’t work as intended: editors write cursor state to the correct field, but doesn’t read back from it when rendering cursors.

This fixes #86

# Current Behavior
If a custom value of `cursorStateField` is set, the cursor plugin correctly uses it to set awareness state: 
https://github.com/yjs/y-prosemirror/blob/fd08cf3c7c307c1446178765baa94603a3a8416a/src/plugins/cursor-plugin.js#L239-L242

However, in the `createDecorations` function, the value `aw.cursor` is still used. This is reading a hardcoded field with the name `"cursor"` from the awareness state. 
https://github.com/yjs/y-prosemirror/blob/fd08cf3c7c307c1446178765baa94603a3a8416a/src/plugins/cursor-plugin.js#L101-L112

This results in cursors not rendering properly if you set `cursorStateField` to a custom value.

# Proposed Changes

- All references to a hardcoded `"cursor"` field are replaced with a dynamic reference to the field name set in `cursorStateField`.

- In `updateCursorInfo`, the condition to clear cursor state and set it to `null` is simplified, so that when the `focusout` event fires, we always run `awareness.setLocalStateField(cursorStateField, null)`. Without this change, if the editor loses focus, the cursor state isn’t properly cleared, which leads to lingering cursors.

# Tests
- I ran `npm run test` and confirmed that all tests are successful
- I manually tested this in my own repo and confirmed that this fixes the original issue where cursor state between subdocuments are wrongly replicated. With this fix, if a subdocument’s guid is passed into the `cursorStateField` param, each subdocument’s cursor state will now sync to separate awareness fields.