### PR TITLE
feat: support overlapping marks #34 based on (#52)

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -395,18 +395,37 @@ export function yXmlFragmentToProsemirrorJSON (xmlFragment) {
         }
 
         if (d.attributes) {
-          text.marks = Object.keys(d.attributes).map((type) => {
+          const marks = []
+
+          Object.keys(d.attributes).forEach((type) => {
             const attrs = d.attributes[type]
-            const mark = {
-              type
-            }
+            if (Array.isArray(attrs)) {
+              // multiple marks of same type
+              attrs.forEach(singleAttrs => {
+                const mark = {
+                  type
+                }
 
-            if (Object.keys(attrs)) {
-              mark.attrs = attrs
-            }
+                if (Object.keys(singleAttrs)) {
+                  mark.attrs = singleAttrs
+                }
 
-            return mark
+                marks.push(mark)
+              })
+            } else {
+              const mark = {
+                type
+              }
+
+              if (Object.keys(attrs)) {
+                mark.attrs = attrs
+              }
+
+              marks.push(mark)
+            }
           })
+
+          text.marks = marks
         }
         return text
       })

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,4 +1,4 @@
-import { updateYFragment, createNodeFromYElement } from './plugins/sync-plugin.js' // eslint-disable-line
+import { updateYFragment, createNodeFromYElement, MarkPrefix } from './plugins/sync-plugin.js' // eslint-disable-line
 import { ySyncPluginKey } from './plugins/keys.js'
 import * as Y from 'yjs'
 import { EditorView } from 'prosemirror-view' // eslint-disable-line
@@ -416,8 +416,20 @@ export function yXmlFragmentToProsemirrorJSON (xmlFragment) {
       }
 
       const attrs = item.getAttributes()
-      if (Object.keys(attrs).length) {
-        response.attrs = attrs
+
+      // Add all non-mark attributes to the element
+      for (const key of Object.keys(attrs).filter((key) => !key.startsWith(MarkPrefix))) {
+        if (!response.attrs) response.attrs = {}
+        response.attrs[key] = attrs[key]
+      }
+
+      // Check whether the attrs contains marks, if so, add them to the response
+      if (Object.keys(attrs).some((key) => key.startsWith(MarkPrefix))) {
+        response.marks = Object.keys(attrs)
+          .filter((key) => key.startsWith(MarkPrefix))
+          .map((key) => {
+            return attrs[key]
+          })
       }
 
       const children = item.toArray()

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -20,6 +20,9 @@ import * as random from 'lib0/random'
 import * as environment from 'lib0/environment'
 import * as dom from 'lib0/dom'
 import * as eventloop from 'lib0/eventloop'
+import * as f from 'lib0/function'
+
+export const MarkPrefix = '_mark_'
 
 /**
  * @param {Y.Item} item
@@ -723,7 +726,22 @@ export const createNodeFromYElement = (
           : { type: 'added' }
       }
     }
-    const node = schema.node(el.nodeName, attrs, children)
+    const nodeAttrs = {}
+    const nodeMarks = []
+
+    for (const key in attrs) {
+      if (key.startsWith(MarkPrefix)) {
+        const markName = key.replace(MarkPrefix, '')
+        const markValue = attrs[key]
+        if (isObject(markValue)) {
+          nodeMarks.push(schema.mark(markName, /** @type {Object} */ (markValue).attrs))
+        }
+      } else {
+        nodeAttrs[key] = attrs[key]
+      }
+    }
+
+    const node = schema.node(el.nodeName, nodeAttrs, children, nodeMarks)
     mapping.set(el, node)
     return node
   } catch (e) {
@@ -802,11 +820,15 @@ const createTypeFromTextNodes = (nodes, mapping) => {
  */
 const createTypeFromElementNode = (node, mapping) => {
   const type = new Y.XmlElement(node.type.name)
+  const nodeMarksAttr = nodeMarksToAttributes(node.marks)
   for (const key in node.attrs) {
     const val = node.attrs[key]
     if (val !== null && key !== 'ychange') {
       type.setAttribute(key, val)
     }
+  }
+  for (const key in nodeMarksAttr) {
+    type.setAttribute(key, nodeMarksAttr[key])
   }
   type.insert(
     0,
@@ -835,13 +857,27 @@ const equalAttrs = (pattrs, yattrs) => {
   const keys = Object.keys(pattrs).filter((key) => pattrs[key] !== null)
   let eq =
     keys.length ===
-      Object.keys(yattrs).filter((key) => yattrs[key] !== null).length
+    Object.keys(yattrs).filter((key) => yattrs[key] !== null && !key.startsWith(MarkPrefix)).length
   for (let i = 0; i < keys.length && eq; i++) {
     const key = keys[i]
     const l = pattrs[key]
     const r = yattrs[key]
     eq = key === 'ychange' || l === r ||
       (isObject(l) && isObject(r) && equalAttrs(l, r))
+  }
+  return eq
+}
+
+const equalMarks = (pmarks, yattrs) => {
+  const keys = Object.keys(yattrs).filter((key) => key.startsWith(MarkPrefix))
+  let eq =
+    keys.length === pmarks.length
+  const pMarkAttr = nodeMarksToAttributes(pmarks)
+  for (let i = 0; i < keys.length && eq; i++) {
+    const key = keys[i]
+    const l = pMarkAttr[key]
+    const r = yattrs[key]
+    eq = key === 'ychange' || f.equalityDeep(l, r)
   }
   return eq
 }
@@ -900,7 +936,8 @@ const equalYTypePNode = (ytype, pnode) => {
   ) {
     const normalizedContent = normalizePNodeContent(pnode)
     return ytype._length === normalizedContent.length &&
-      equalAttrs(ytype.getAttributes(), pnode.attrs) &&
+      equalAttrs(pnode.attrs, ytype.getAttributes()) &&
+      equalMarks(pnode.marks, ytype.getAttributes()) &&
       ytype.toArray().every((ychild, i) =>
         equalYTypePNode(ychild, normalizedContent[i])
       )
@@ -1017,6 +1054,16 @@ const marksToAttributes = (marks) => {
   return pattrs
 }
 
+const nodeMarksToAttributes = (marks) => {
+  const pattrs = {}
+  marks.forEach((mark) => {
+    if (mark.type.name !== 'ychange') {
+      pattrs[`${MarkPrefix}${mark.type.name}`] = mark.toJSON()
+    }
+  })
+  return pattrs
+}
+
 /**
  * Update a yDom node by syncing the current content of the prosemirror node.
  *
@@ -1042,10 +1089,13 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
   if (yDomFragment instanceof Y.XmlElement) {
     const yDomAttrs = yDomFragment.getAttributes()
     const pAttrs = pNode.attrs
-    for (const key in pAttrs) {
-      if (pAttrs[key] !== null) {
-        if (yDomAttrs[key] !== pAttrs[key] && key !== 'ychange') {
-          yDomFragment.setAttribute(key, pAttrs[key])
+    const pNodeMarksAttr = nodeMarksToAttributes(pNode.marks)
+    const attrs = { ...pAttrs, ...pNodeMarksAttr }
+
+    for (const key in attrs) {
+      if (attrs[key] !== null) {
+        if (yDomAttrs[key] !== attrs[key] && key !== 'ychange') {
+          yDomFragment.setAttribute(key, attrs[key])
         }
       } else {
         yDomFragment.removeAttribute(key)
@@ -1053,7 +1103,7 @@ export const updateYFragment = (y, yDomFragment, pNode, mapping) => {
     }
     // remove all keys that are no longer in pAttrs
     for (const key in yDomAttrs) {
-      if (pAttrs[key] === undefined) {
+      if (attrs[key] === undefined) {
         yDomFragment.removeAttribute(key)
       }
     }

--- a/tests/complexSchema.js
+++ b/tests/complexSchema.js
@@ -157,6 +157,7 @@ export const nodes = {
 const emDOM = ['em', 0]
 const strongDOM = ['strong', 0]
 const codeDOM = ['code', 0]
+const commentDOM = ['span', 0]
 
 // :: Object [Specs](#model.MarkSpec) for the marks in the schema.
 export const marks = {
@@ -221,6 +222,17 @@ export const marks = {
     parseDOM: [{ tag: 'code' }],
     toDOM () {
       return codeDOM
+    }
+  },
+
+  comment: {
+    attrs: {
+      id: { default: null }
+    },
+    exclude: '', // allow multiple "comments" marks to overlap
+    parseDOM: [{ tag: 'span' }],
+    toDOM () {
+      return commentDOM
     }
   },
 


### PR DESCRIPTION
This adds support for overlapping marks to both text elements and nodes, it is based on (#52) but is:
 - based in a much more recent branch which adds node mark support (#157)
 - supports multiple node marks based on the work set up by (#157)
 - passes tests
