### PR TITLE
fix: avoid throwing an exception if the restored selection does not make sense

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -245,7 +245,9 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
       binding.mapping
     )
     if (anchor !== null && head !== null) {
-      tr = tr.setSelection(TextSelection.create(tr.doc, anchor, head))
+      const clampedAnchor = math.min(math.max(anchor, 0), tr.doc.content.size)
+      const clampedHead = math.min(math.max(head, 0), tr.doc.content.size)
+      tr = tr.setSelection(TextSelection.create(tr.doc, clampedAnchor, clampedHead))
     }
   }
 }


### PR DESCRIPTION
Similarly to https://github.com/yjs/y-prosemirror/issues/170, in some rare cases `restoreRelativeSelection` in `_typeChanged` can't restore the selection and throws an exception. This happens when the yjs document can't be perfectly converted to the prosemirror document because of schema restrictions.