### PR TITLE
fix: return both mapping and meta

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -234,7 +234,7 @@ export const initProseMirrorDoc = (yXmlFragment, schema) => {
     )
   ).filter((n) => n !== null)
   const doc = schema.topNodeType.create(null, Fragment.fromArray(fragmentContent))
-  return { doc, meta: meta.mapping }
+  return { doc, meta, mapping: meta.mapping }
 }
 
 /**


### PR DESCRIPTION
This fixes an issue introduced in 1.3.0 where the signature of `initProseMirrorDoc` was changed in a backwards-incompatible way.

This introduces the intended change in a backwards-compatible and user-friendly way by providing both the mapping (which they may need for the sync plugin) and the meta binding (which they may need for updateYFragment like I did)
