### PR TITLE
Add `undoCommand` & `redoCommand` for prosemirror-history compatible API

### DIFF
--- a/src/plugins/keys.js
+++ b/src/plugins/keys.js
@@ -11,6 +11,7 @@ export const ySyncPluginKey = new PluginKey('y-sync')
  * The unique prosemirror plugin key for undoPlugin
  *
  * @public
+ * @type {PluginKey<import('./undo-plugin').UndoPluginState>}
  */
 export const yUndoPluginKey = new PluginKey('y-undo')
 

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -30,7 +30,7 @@ import * as utils from '../utils.js'
  */
 
 /**
- * @return BindingMetadata
+ * @return {BindingMetadata}
  */
 export const createEmptyMeta = () => ({
   mapping: new Map(),


### PR DESCRIPTION
This refactors the `undo-plugin` to:
 - add TypeScript types for the `undo-plugin` state
 - add new `undoCommand` and `redoCommand` exports which will only modify the state if `dispatch` is present
 - `undoCommand` and `redoCommand` now only undo/redo if there is something to actually undo/redo

I made these as separate commands since this was going to be a breaking change for existing users (since `dispatch` is now required to execute).

## Why do it like this though?

This is more in-line with how prosemirror intends things to work. Where it can be useful to have a command run without the dispatch function to see if the command can run (e.g. to enable/disable undo & redo buttons).
This is also matching the implementation set forth by prosemirror-history, making it trivial to replace the two implementations 
