### PR TITLE
fix: clamp positions if out of bounds

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -272,7 +272,10 @@ const restoreRelativeSelection = (tr, relSel, binding) => {
         binding.mapping
       )
       if (anchor !== null && head !== null) {
-        tr.setSelection(TextSelection.between(tr.doc.resolve(anchor), tr.doc.resolve(head)))
+        const maxsize = tr.doc.content.size - 1
+        const clampedAnchor = math.min(math.max(anchor, 0), maxsize)
+        const clampedHead = math.min(math.max(head, 0), maxsize)
+        tr.setSelection(TextSelection.between(tr.doc.resolve(clampedAnchor), tr.doc.resolve(clampedHead)))
       }
     }
   }


### PR DESCRIPTION
On looking into this comment: https://github.com/yjs/y-prosemirror/pull/176#issuecomment-2825364764 it turns out that he is right, I was able to get a failed selection restoration because the position was restored outside the bounds of the document. I'm not entirely clear how this occurs, but clamping the position to the document size seems like the right thing to do
