### PR TITLE
Fix incorrect node updates by wrong right side match

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -1192,7 +1192,7 @@ export const updateYFragment = (y, yDomFragment, pNode, meta) => {
     }
   }
   // find number of matching elements from right
-  for (; right + left + 1 < minCnt; right++) {
+  for (; right + left < minCnt; right++) {
     const rightY = yChildren[yChildCnt - right - 1]
     const rightP = pChildren[pChildCnt - right - 1]
     if (!mappedIdentity(meta.mapping.get(rightY), rightP)) {

--- a/tests/y-prosemirror.test.js
+++ b/tests/y-prosemirror.test.js
@@ -310,6 +310,47 @@ export const testInsertDuplication = (_tc) => {
   t.assert(yxml1.toString() === '<paragraph>1122</paragraph><paragraph></paragraph>')
 }
 
+export const testInsertRightMatch = (_tc) => {
+  const ydoc = new Y.Doc()
+  const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment)
+  const view = createNewProsemirrorView(ydoc)
+  view.dispatch(
+    view.state.tr.insert(
+      0,
+      [
+        schema.node(
+          'heading',
+          { level: 1 },
+          schema.text('Heading 1')
+        ),
+        schema.node(
+          'paragraph',
+          undefined,
+          schema.text('Paragraph 1')
+        )
+      ]
+    )
+  )
+  prosemirrorJSONToYXmlFragment(/** @type {any} */ (schema), view.state.doc.toJSON(), yXmlFragment)
+  const lastP = yXmlFragment.get(yXmlFragment.length - 1)
+  const tr = view.state.tr
+  view.dispatch(
+    tr.insert(
+      tr.doc.child(0).nodeSize + tr.doc.child(1).nodeSize,
+      schema.node(
+        'paragraph',
+        undefined,
+        schema.text('Paragraph 2')
+      )
+    )
+  )
+  const newLastP = yXmlFragment.get(yXmlFragment.length - 1)
+  const new2ndLastP = yXmlFragment.get(yXmlFragment.length - 2)
+  t.assert(lastP === newLastP, 'last paragraph is the same as before')
+  t.assert(new2ndLastP.toString() === '<paragraph>Paragraph 2</paragraph>', '2nd last paragraph is the inserted paragraph')
+  t.assert(lastP.toString() === '<paragraph></paragraph>', 'last paragraph remains empty and is placed at the end')
+}
+
 export const testAddToHistory = (_tc) => {
   const ydoc = new Y.Doc()
   const view = createNewProsemirrorViewWithUndoManager(ydoc)


### PR DESCRIPTION
## The Issue

When inserting content between existing nodes, the sync logic incorrectly updated the last paragraph instead of inserting a new paragraph before it.

### Insert Paragraph 2
| `<h1>Heading</h1>`    | `<h1>Heading</h1>`    |
|---------------------|--------------------|
| `<p>Paragraph 1</p>`  | `<p>Paragraph 1</p>`  |
| `<p>Paragraph 2</p>`  | `<p></p>`             |
| `<p></p>`             |                     |

### Current Sync logic
| ProseMirror         | Matched Yjs Elem     | Result Yjs Elem             |
|---------------------|----------------------|-----------------------------|
| `<h1>Heading</h1>`    | = `<h1>Heading</h1>`   | `<h1>Heading</h1>`            |
| `<p>Paragraph 1</p>`  | = `<p>Paragraph 1</p>` | `<p>Paragraph 1</p>`          |
| `<p>Paragraph 2</p>`  |   `<p></p>`            | `<p>Paragraph 2</p>` UPDATED  |
| `<p></p>`             |                      | `<p></p>` INSERTED            |

### Fixed Sync logic
| ProseMirror         | Matched Yjs Elem     | Result Yjs Elem             |
|---------------------|----------------------|-----------------------------|
| `<h1>Heading</h1>`    | = `<h1>Heading</h1>`   | `<h1>Heading</h1>`            |
| `<p>Paragraph 1</p>`  | = `<p>Paragraph 1</p>` | `<p>Paragraph 1</p>`          |
| `<p>Paragraph 2</p>`  |                      | `<p>Paragraph 2</p>` INSERTED |
| `<p></p>`             | = `<p></p>`            | `<p></p>`                     |

---

While it might be difficult to guarantee how content will be synced in all cases, I'm experiencing issues in a scenario where multiple AI agents are writing simultaneously.
This fix would be greatly appreciated as it resolves the problems I'm encountering in that use case.
