### PR TITLE
Fix undo inside custom element

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -372,7 +372,7 @@ export class ProsemirrorBinding {
 
     if (selection == null || selection.anchorNode == null) return false
 
-    const range = this.prosemirrorView._root.createRange()
+    const range = dom.doc.createRange()
     range.setStart(selection.anchorNode, selection.anchorOffset)
     range.setEnd(selection.focusNode, selection.focusOffset)
 


### PR DESCRIPTION
While using prosemirror inside Custom Element this line fails.
In such case `this.prosemirrorView._root` is set to `ShadowRoot` not `Document`.
Method createRange exists only in `Document`.