### PR TITLE
fix: Prosemirror inside Webcomponent needs to use ownerDocument

### DIFF
--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -373,7 +373,6 @@ export class ProsemirrorBinding {
 
     if (selection == null || selection.anchorNode == null) return false
 
-    
     const range = document.createRange()
     range.setStart(selection.anchorNode, selection.anchorOffset)
     range.setEnd(selection.focusNode, selection.focusOffset)

--- a/src/plugins/sync-plugin.js
+++ b/src/plugins/sync-plugin.js
@@ -368,11 +368,13 @@ export class ProsemirrorBinding {
   }
 
   _isDomSelectionInView () {
-    const selection = this.prosemirrorView._root.getSelection()
+    const document = this.prosemirrorView._root.createRange ? this.prosemirrorView._root : this.prosemirrorView._root.ownerDocument
+    const selection = document.getSelection()
 
     if (selection == null || selection.anchorNode == null) return false
 
-    const range = this.prosemirrorView._root.createRange()
+    
+    const range = document.createRange()
     range.setStart(selection.anchorNode, selection.anchorOffset)
     range.setEnd(selection.focusNode, selection.focusOffset)
 


### PR DESCRIPTION
When Prosemirror is initialized inside a webcomponent, `this.prosemirrorView._root` is a `ShadowRoot` which does not have a`createRange` method available on it, causing this error.

<img width="792" height="141" alt="Screenshot 2025-09-14 at 15 37 10" src="https://github.com/user-attachments/assets/98f32c74-6bd0-4062-b9ce-4a9dceb50aea" />

* This is backwards compatible:
If `createRange` function is available, `_root` is `Document`, so no change
if not, `_root` we assume it is `ShadowRoot`, and use the `.ownerDocument` function. 

* the code does not error on `getSelection`, but for consistency, I made the change here too 👍 


Lmk if you have any questions :). I'd be happy to repro as well 