### PR TITLE
Prevent operations on destroyed views

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -24,6 +24,9 @@ const updateMetas = () => {
   const ups = /** @type {Map<EditorView, Map<any, any>>} */ (viewsToUpdate)
   viewsToUpdate = null
   ups.forEach((metas, view) => {
+    if (view.isDestroyed) {
+      return
+    }
     const tr = view.state.tr
     const syncState = ySyncPluginKey.getState(view.state)
     if (syncState && syncState.binding && !syncState.binding.isDestroyed) {


### PR DESCRIPTION
I encountered the following error during my unit tests:

```
Uncaught TypeError: Cannot read properties of null (reading 'matchesNode')
    at EditorView.updateStateInner (chunk-VVQZWLTC.js?v=83ef0d59:4795:45)
    at EditorView.updateState (chunk-VVQZWLTC.js?v=83ef0d59:4770:10)
    at EditorView.dispatch (chunk-VVQZWLTC.js?v=83ef0d59:5115:10)
    at y-prosemirror.js?v=ab00c66d:1219:12
    at Map.forEach (<anonymous>)
    at updateMetas (y-prosemirror.js?v=ab00c66d:1212:7)
```

This error appears in `view.dispatch(tr)` at [lib.js#L33](https://github.com/yjs/y-prosemirror/blob/f89fadd2a8bf15c0c7e6bfcac268883a5fa4e0f8/src/lib.js#L33), which is wrapped in a `eventloop.timeout` / `setTimeout`.

While I haven't specifically tried to reproduce this error during typical user operations, it may not pose a problem for actual users since it seems to be a timing issue, and automated tests generally run faster than human interactions. Nevertheless, I believe it's a good idea to check `view.isDestroyed` in asynchronous (i.e., `setTimeout`) operations to prevent such issues.

In this PR, I added a `view.isDestroyed` check before `view.dispatch(tr)` in this place.

Sidenote: In [sync-plugin.js](https://github.com/yjs/y-prosemirror/blob/f89fadd2a8bf15c0c7e6bfcac268883a5fa4e0f8/src/plugins/sync-plugin.js#L407), there are also some `this.prosemirrorView.dispatch()` calls. It could be a good idea to check `view.isDestroyed` before calling `.dispatch()`, but I'm not certain if it's necessary. @dmonad Do you think I should add `view.isDestroyed` check for them too?