### PR TITLE
fix: improve cursor updates in wrapped editors

### DIFF
--- a/src/cursor-plugin.js
+++ b/src/cursor-plugin.js
@@ -180,9 +180,11 @@ export const yCursorPlugin = (
       },
       apply (tr, prevState, _oldState, newState) {
         const ySyncMeta = $syncPluginStateUpdate.nullable.expect(tr.getMeta(ySyncPluginKey) || null)
+        const ySyncTransaction = tr.getMeta('y-sync-transaction')
         const yCursorState = tr.getMeta(yCursorPluginKey)
         if (
           (ySyncMeta) ||
+          (ySyncTransaction) ||
           (yCursorState && yCursorState.awarenessUpdated)
         ) {
           return createDecorations(

--- a/src/cursor-plugin.js
+++ b/src/cursor-plugin.js
@@ -203,11 +203,29 @@ export const yCursorPlugin = (
       }
     },
     view: (view) => {
+      const ownerDocument = view.dom.ownerDocument
+      let cursorUpdateScheduled = false
+      const isEditorFocused = () => {
+        const activeElement = ownerDocument.activeElement
+        return (
+          activeElement === view.dom ||
+          (activeElement instanceof Element && view.dom.contains(activeElement))
+        )
+      }
+      const scheduleCursorUpdate = () => {
+        if (cursorUpdateScheduled) return
+        cursorUpdateScheduled = true
+        queueMicrotask(() => {
+          cursorUpdateScheduled = false
+          updateCursorInfo()
+        })
+      }
       const awarenessListener = () => {
-        // @ts-ignore
-        if (view.docView) { // TODO why is this using docView? Ask Kevin about this.
-          view.dispatch(view.state.tr.setMeta(yCursorPluginKey, { awarenessUpdated: true }))
-        }
+        queueMicrotask(() => {
+          const tr = view.state.tr.setMeta(yCursorPluginKey, { awarenessUpdated: true })
+          tr.setMeta('addToHistory', false)
+          view.dispatch(tr)
+        })
       }
       const updateCursorInfo = () => {
         const ystate = ySyncPluginKey.getState(view.state)
@@ -217,7 +235,7 @@ export const yCursorPlugin = (
          * @type {{anchor: any, head: any}}
          */
         const cursor = current[cursorStateField]
-        if (view.hasFocus() && ystate?.ytype) {
+        if (isEditorFocused() && ystate?.ytype) {
           const selection = getSelection(view.state)
           const anchor = absolutePositionToRelativePosition(
             selection.$anchor,
@@ -259,14 +277,27 @@ export const yCursorPlugin = (
           awareness.setLocalStateField(cursorStateField, null)
         }
       }
+      const handleSelectionChange = () => {
+        if (isEditorFocused()) {
+          scheduleCursorUpdate()
+        }
+      }
       awareness.on('change', awarenessListener)
-      view.dom.addEventListener('focusin', updateCursorInfo)
-      view.dom.addEventListener('focusout', updateCursorInfo)
+      view.dom.addEventListener('focusin', scheduleCursorUpdate)
+      view.dom.addEventListener('focusout', scheduleCursorUpdate)
+      view.dom.addEventListener('keyup', scheduleCursorUpdate)
+      view.dom.addEventListener('mouseup', scheduleCursorUpdate)
+      view.dom.addEventListener('touchend', scheduleCursorUpdate)
+      ownerDocument.addEventListener('selectionchange', handleSelectionChange)
       return {
-        update: updateCursorInfo,
+        update: scheduleCursorUpdate,
         destroy: () => {
-          view.dom.removeEventListener('focusin', updateCursorInfo)
-          view.dom.removeEventListener('focusout', updateCursorInfo)
+          view.dom.removeEventListener('focusin', scheduleCursorUpdate)
+          view.dom.removeEventListener('focusout', scheduleCursorUpdate)
+          view.dom.removeEventListener('keyup', scheduleCursorUpdate)
+          view.dom.removeEventListener('mouseup', scheduleCursorUpdate)
+          view.dom.removeEventListener('touchend', scheduleCursorUpdate)
+          ownerDocument.removeEventListener('selectionchange', handleSelectionChange)
           awareness.off('change', awarenessListener)
           awareness.setLocalStateField(cursorStateField, null)
         }


### PR DESCRIPTION
Hey 👋

I've been experimenting with the new version of this integration from `main` with yjs v14. *Really* excited what this is going to bring!

The demo I have been building that I'm hoping to port to this uses [react-prosemirror](https://github.com/handlewithcarecollective/react-prosemirror), and it seems the cursor-plugin isn't quite compatible with it. The symptoms were that the remote cursor would only appear on first render and then not update in real time.

I worked with Cursor to debug it, and this is what it came up with, and it seems fairly sure it's due to the way react-prosemirror wraps the editor view with its own render layer. The changes seem logical to me.

This is its description of its changes:

---

We changed the cursor plugin to make collaborative cursor updates more reliable in wrapped ProseMirror editors.

What changed:
- redraw cursor decorations on incoming awareness changes by dispatching the plugin transaction
- stop relying only on `view.hasFocus()` and instead treat the editor as focused when the active DOM element is the editor or one of its descendants
- publish cursor updates from real selection movement signals like `selectionchange`, `keyup`, `mouseup`, and `touchend`
- coalesce those updates in a microtask so they don’t fire excessively

Why:
- cursor state could appear on load but not update live as another user moved their caret or edited
- in practice, updates were sometimes only reflected after a reload, which suggested the plugin was missing normal selection/focus timing in our integration

Suspicion:
- this looks related to how `@handlewithcare/react-prosemirror` wraps the editor view
- the stock cursor plugin logic seems to assume more direct `EditorView` focus/update behavior than we were seeing, so these changes make the plugin less dependent on those assumptions