### PR TITLE
fix: implicitly create "filled" prosemirror nodes to not crash the editor

### DIFF
--- a/src/sync-utils.js
+++ b/src/sync-utils.js
@@ -325,9 +325,19 @@ export const deltaToPNode = (d, schema, dformat) => {
     attrs[attr.key] = attr.value
   }
   const dc = d.children.map(c => delta.$insertOp.check(c) ? c.insert.map(cn => deltaToPNode(cn, schema, c.format)) : (delta.$textOp.check(c) ? [schema.text(c.insert, formattingAttributesToMarks(c.format, schema))] : []))
-  const pNode = schema.nodes[d.name ?? 'doc'].createAndFill(attrs, dc.flat(1), formattingAttributesToMarks(dformat, schema))
+  const nodeType = schema.nodes[d.name ?? 'doc']
+  if (!nodeType) {
+    throw new Error(
+      '[y/prosemirror]: node type does not exist in the schema: ' + d.name
+    )
+  }
+  const pNode = nodeType.createAndFill(
+    attrs,
+    dc.flat(1),
+    formattingAttributesToMarks(dformat, schema)
+  )
   if (pNode === null) {
-    throw new Error('Failed to create node')
+    throw new Error('[y/prosemirror]: failed to create node: ' + d.name)
   }
   return pNode
 }

--- a/src/sync-utils.js
+++ b/src/sync-utils.js
@@ -325,7 +325,11 @@ export const deltaToPNode = (d, schema, dformat) => {
     attrs[attr.key] = attr.value
   }
   const dc = d.children.map(c => delta.$insertOp.check(c) ? c.insert.map(cn => deltaToPNode(cn, schema, c.format)) : (delta.$textOp.check(c) ? [schema.text(c.insert, formattingAttributesToMarks(c.format, schema))] : []))
-  return schema.node(d.name ?? 'doc', attrs, dc.flat(1), formattingAttributesToMarks(dformat, schema))
+  const pNode = schema.nodes[d.name ?? 'doc'].createAndFill(attrs, dc.flat(1), formattingAttributesToMarks(dformat, schema))
+  if (pNode === null) {
+    throw new Error('Failed to create node')
+  }
+  return pNode
 }
 
 /**

--- a/tests/delta.test.js
+++ b/tests/delta.test.js
@@ -7,7 +7,6 @@ import { Fragment, Schema, Slice } from 'prosemirror-model'
 import * as delta from 'lib0/delta'
 import { findWrapping, ReplaceAroundStep } from 'prosemirror-transform'
 import { EditorView } from 'prosemirror-view'
-import { deltaToPNode } from '../src/sync-utils.js'
 
 const schema = new Schema({
   nodes: basicSchema.nodes,
@@ -56,8 +55,12 @@ const validate = pm => {
 
 /**
  * @param {Array<(opts:YPMTestConf)=>(delta.DeltaAny|import('prosemirror-state').Transaction|null)>} changes
+ * @param {delta.Delta} [initialDelta]
  */
-const testHelper = changes => {
+const testHelper = (changes,
+  // never change this structure!
+  // <heading>[1]Hello World![13]</heading>[14]<paragraph>[15]Lorem [21]ipsum..[28]</paragraph>[29]
+  initialDelta = (delta.create().insert([delta.create('heading', { level: 1 }, 'Hello World!'), delta.create('paragraph', {}, 'Lorem ipsum..')]).done())) => {
   // sync two ydocs
   const ydoc = new Y.Doc()
   const ydoc2 = new Y.Doc()
@@ -68,9 +71,8 @@ const testHelper = changes => {
     Y.applyUpdate(ydoc, update)
   })
   const ytype = ydoc.get('prosemirror')
-  // never change this structure!
-  // <heading>[1]Hello World![13]</heading>[14]<paragraph>[15]Lorem [21]ipsum..[28]</paragraph>[29]
-  ytype.applyDelta(delta.create().insert([delta.create('heading', { level: 1 }, 'Hello World!'), delta.create('paragraph', {}, 'Lorem ipsum..')]).done())
+
+  ytype.applyDelta(initialDelta)
   const view = createProsemirrorView(ytype)
   const view2 = createProsemirrorView(ydoc2.get('prosemirror'))
 
@@ -180,89 +182,19 @@ export const testMultipleComplexSteps = () => {
   ])
 }
 
-// --- deltaToPNode direct tests ---
-
-/**
- * Test that deltaToPNode creates a simple paragraph with text content.
- */
-export const testDeltaToPNodeParagraph = () => {
-  const d = delta.create('paragraph', {}, 'Hello')
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'paragraph')
-  t.assert(node.textContent === 'Hello')
+export const testFilledBlockquote = () => {
+  testHelper([
+    ({ tr }) => {
+      console.log(tr.doc.toString())
+      return tr
+    }
+  ],
+  // blockquote needs a paragraph with block+, but we intentionally don't create it here
+  delta.create().insert([delta.create('blockquote', {})]).done())
 }
 
-/**
- * Test that deltaToPNode creates a heading with attributes.
- */
-export const testDeltaToPNodeHeadingWithAttrs = () => {
-  const d = delta.create('heading', { level: 2 }, 'Title')
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'heading')
-  t.assert(node.attrs.level === 2)
-  t.assert(node.textContent === 'Title')
-}
-
-/**
- * Test that deltaToPNode creates an empty paragraph (inline* content allows empty).
- */
-export const testDeltaToPNodeEmptyParagraph = () => {
-  const d = delta.create('paragraph', {})
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'paragraph')
-  t.assert(node.childCount === 0)
-}
-
-/**
- * Test that createAndFill auto-fills required children for blockquote.
- * blockquote has content "block+" so it requires at least one block child.
- * createAndFill should auto-insert an empty paragraph, whereas the old
- * schema.node() would have thrown an error.
- */
-export const testDeltaToPNodeAutoFillsBlockquote = () => {
-  const d = delta.create('blockquote', {})
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'blockquote')
-  // createAndFill should have auto-inserted a paragraph to satisfy block+ content
-  t.assert(node.childCount === 1)
-  t.assert(node.firstChild?.type.name === 'paragraph')
-}
-
-/**
- * Test that deltaToPNode handles a blockquote with an explicit paragraph child.
- */
-export const testDeltaToPNodeBlockquoteWithChild = () => {
-  const d = delta.create('blockquote', {}, [delta.create('paragraph', {}, 'quoted text')])
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'blockquote')
-  t.assert(node.childCount === 1)
-  t.assert(node.firstChild?.type.name === 'paragraph')
-  t.assert(node.firstChild?.textContent === 'quoted text')
-}
-
-/**
- * Test that deltaToPNode produces a doc node with auto-filled paragraph
- * when created with no children (basic schema doc has content "block+").
- */
-export const testDeltaToPNodeAutoFillsDoc = () => {
-  const d = delta.create(null, {})
-  // @ts-ignore - deltaToPNode handles name=null at runtime (falls back to 'doc')
-  const node = deltaToPNode(d, schema, null)
-  t.assert(node.type.name === 'doc')
-  // createAndFill should auto-insert a paragraph to satisfy block+ content
-  t.assert(node.childCount === 1)
-  t.assert(node.firstChild?.type.name === 'paragraph')
-}
-
-/**
- * Test that deltaToPNode applies marks from dformat parameter.
- */
-export const testDeltaToPNodeWithFormat = () => {
-  const d = delta.create('paragraph', {}, 'bold text')
-  const format = { strong: true }
-  const node = deltaToPNode(d, schema, format)
-  t.assert(node.type.name === 'paragraph')
-  // The dformat marks are applied to the node itself as stored marks
-  // Verify the node was created successfully with the format
-  t.assert(node.textContent === 'bold text')
+export const testFilledBlockquoteInsert = () => {
+  testHelper([
+    ({ tr }) => tr.insertText('Hello', 2)
+  ], delta.create().insert([delta.create('blockquote', {})]).done())
 }

--- a/tests/delta.test.js
+++ b/tests/delta.test.js
@@ -246,6 +246,7 @@ export const testDeltaToPNodeBlockquoteWithChild = () => {
  */
 export const testDeltaToPNodeAutoFillsDoc = () => {
   const d = delta.create(null, {})
+  // @ts-ignore - deltaToPNode handles name=null at runtime (falls back to 'doc')
   const node = deltaToPNode(d, schema, null)
   t.assert(node.type.name === 'doc')
   // createAndFill should auto-insert a paragraph to satisfy block+ content

--- a/tests/delta.test.js
+++ b/tests/delta.test.js
@@ -7,6 +7,7 @@ import { Fragment, Schema, Slice } from 'prosemirror-model'
 import * as delta from 'lib0/delta'
 import { findWrapping, ReplaceAroundStep } from 'prosemirror-transform'
 import { EditorView } from 'prosemirror-view'
+import { deltaToPNode } from '../src/sync-utils.js'
 
 const schema = new Schema({
   nodes: basicSchema.nodes,
@@ -177,4 +178,90 @@ export const testMultipleComplexSteps = () => {
       return tr
     }
   ])
+}
+
+// --- deltaToPNode direct tests ---
+
+/**
+ * Test that deltaToPNode creates a simple paragraph with text content.
+ */
+export const testDeltaToPNodeParagraph = () => {
+  const d = delta.create('paragraph', {}, 'Hello')
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'paragraph')
+  t.assert(node.textContent === 'Hello')
+}
+
+/**
+ * Test that deltaToPNode creates a heading with attributes.
+ */
+export const testDeltaToPNodeHeadingWithAttrs = () => {
+  const d = delta.create('heading', { level: 2 }, 'Title')
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'heading')
+  t.assert(node.attrs.level === 2)
+  t.assert(node.textContent === 'Title')
+}
+
+/**
+ * Test that deltaToPNode creates an empty paragraph (inline* content allows empty).
+ */
+export const testDeltaToPNodeEmptyParagraph = () => {
+  const d = delta.create('paragraph', {})
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'paragraph')
+  t.assert(node.childCount === 0)
+}
+
+/**
+ * Test that createAndFill auto-fills required children for blockquote.
+ * blockquote has content "block+" so it requires at least one block child.
+ * createAndFill should auto-insert an empty paragraph, whereas the old
+ * schema.node() would have thrown an error.
+ */
+export const testDeltaToPNodeAutoFillsBlockquote = () => {
+  const d = delta.create('blockquote', {})
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'blockquote')
+  // createAndFill should have auto-inserted a paragraph to satisfy block+ content
+  t.assert(node.childCount === 1)
+  t.assert(node.firstChild?.type.name === 'paragraph')
+}
+
+/**
+ * Test that deltaToPNode handles a blockquote with an explicit paragraph child.
+ */
+export const testDeltaToPNodeBlockquoteWithChild = () => {
+  const d = delta.create('blockquote', {}, [delta.create('paragraph', {}, 'quoted text')])
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'blockquote')
+  t.assert(node.childCount === 1)
+  t.assert(node.firstChild?.type.name === 'paragraph')
+  t.assert(node.firstChild?.textContent === 'quoted text')
+}
+
+/**
+ * Test that deltaToPNode produces a doc node with auto-filled paragraph
+ * when created with no children (basic schema doc has content "block+").
+ */
+export const testDeltaToPNodeAutoFillsDoc = () => {
+  const d = delta.create(null, {})
+  const node = deltaToPNode(d, schema, null)
+  t.assert(node.type.name === 'doc')
+  // createAndFill should auto-insert a paragraph to satisfy block+ content
+  t.assert(node.childCount === 1)
+  t.assert(node.firstChild?.type.name === 'paragraph')
+}
+
+/**
+ * Test that deltaToPNode applies marks from dformat parameter.
+ */
+export const testDeltaToPNodeWithFormat = () => {
+  const d = delta.create('paragraph', {}, 'bold text')
+  const format = { strong: true }
+  const node = deltaToPNode(d, schema, format)
+  t.assert(node.type.name === 'paragraph')
+  // The dformat marks are applied to the node itself as stored marks
+  // Verify the node was created successfully with the format
+  t.assert(node.textContent === 'bold text')
 }


### PR DESCRIPTION
Hi @dmonad, to fix the blocknote demo (which is currently broken), I was going to apply the same fix that [I did here](https://github.com/yjs/y-prosemirror/pull/225#discussion_r3051464129).

After our recent fitting conversation, it made me realize that we can instead fix this by changing the nodes that y-prosemirror generates. 
One thing that is sort of nice about this solution, is that every editor would deterministically fill in the same way (assuming they have the same schema).
So, it seems to just work? Maybe you would know better what could go wrong with this, but from my understanding this is a fine solution to have (and unblocks me by allowing me to use blocknote again).


Let me know what you think!
