### PR TITLE
update blocknote with `excludes: ''`

### DIFF
--- a/yhub-blocknote-demo/package-lock.json
+++ b/yhub-blocknote-demo/package-lock.json
@@ -9,9 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@blocknote/core": "https://pkg.pr.new/@blocknote/core@ac52371",
-        "@blocknote/mantine": "https://pkg.pr.new/@blocknote/mantine@ac52371",
-        "@blocknote/react": "https://pkg.pr.new/@blocknote/react@ac52371",
+        "@blocknote/core": "https://pkg.pr.new/@blocknote/core@2739",
+        "@blocknote/mantine": "https://pkg.pr.new/@blocknote/mantine@2739",
+        "@blocknote/react": "https://pkg.pr.new/@blocknote/react@2739",
         "@y/prosemirror": "file:..",
         "@y/protocols": "^1.0.6-rc.1",
         "@y/websocket": "^4.0.0-rc.1",
@@ -362,9 +362,9 @@
       }
     },
     "node_modules/@blocknote/core": {
-      "version": "0.50.0",
-      "resolved": "https://pkg.pr.new/@blocknote/core@ac52371",
-      "integrity": "sha512-EzMkqA3n6EvlqUEnFTfqBQBETd7qfiIwOZ9rpMIbb1NI9eqFRHDoDr4KTyDf0Pzcz0VBVnnMHZq8JYEc/wpXwQ==",
+      "version": "0.51.2",
+      "resolved": "https://pkg.pr.new/@blocknote/core@2739",
+      "integrity": "sha512-S6LY6xkgRtd0aAsXu56twkMs1MheM/zX6WuiqTuTeOPnd4TpUljsuQJTkBRQf2UWHBX/xxbD4guW9kbZaCLl+g==",
       "license": "MPL-2.0",
       "dependencies": {
         "@emoji-mart/data": "^1.2.1",
@@ -384,16 +384,41 @@
         "@tiptap/pm": "^3.13.0",
         "emoji-mart": "^5.6.0",
         "fast-deep-equal": "^3.1.3",
-        "lib0": "^0.2.99",
+        "lib0": "1.0.0-rc.13",
         "prosemirror-highlight": "^0.15.1",
         "prosemirror-model": "^1.25.4",
         "prosemirror-state": "^1.4.4",
         "prosemirror-tables": "^1.8.3",
         "prosemirror-transform": "^1.11.0",
-        "prosemirror-view": "^1.41.4",
+        "prosemirror-view": "^1.41.4"
+      },
+      "peerDependencies": {
+        "@y/prosemirror": "^2.0.0-2",
+        "@y/protocols": "^1.0.6-rc.1",
+        "@y/y": "^14.0.0-rc.16",
         "y-prosemirror": "^1.3.7",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.27"
+      },
+      "peerDependenciesMeta": {
+        "@y/prosemirror": {
+          "optional": true
+        },
+        "@y/protocols": {
+          "optional": true
+        },
+        "@y/y": {
+          "optional": true
+        },
+        "y-prosemirror": {
+          "optional": true
+        },
+        "y-protocols": {
+          "optional": true
+        },
+        "yjs": {
+          "optional": true
+        }
       }
     },
     "node_modules/@blocknote/core/node_modules/@tiptap/core": {
@@ -552,35 +577,14 @@
         "url": "https://github.com/sponsors/ueberdosis"
       }
     },
-    "node_modules/@blocknote/core/node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/@blocknote/mantine": {
-      "version": "0.50.0",
-      "resolved": "https://pkg.pr.new/@blocknote/mantine@ac52371",
-      "integrity": "sha512-p28H9D2BpmPKmiEh8XADjOcv4m6JYGym9r0qKOWVIiw7RsIYXRRbeDULakIBCnEcNFSSKtNtvCt9UMssqzxy+w==",
+      "version": "0.51.2",
+      "resolved": "https://pkg.pr.new/@blocknote/mantine@2739",
+      "integrity": "sha512-71AJIkx3RqI04D38n7r7nrlZze2F+gP5OyypV5QSRUdmG7yVK4thzqom2rro5mbQ21+usw0seVt5djAdxfZQJw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/core@ac52371",
-        "@blocknote/react": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/react@ac52371",
+        "@blocknote/core": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/core@89669d2",
+        "@blocknote/react": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/react@89669d2",
         "react-icons": "^5.5.0"
       },
       "peerDependencies": {
@@ -591,12 +595,12 @@
       }
     },
     "node_modules/@blocknote/react": {
-      "version": "0.50.0",
-      "resolved": "https://pkg.pr.new/@blocknote/react@ac52371",
-      "integrity": "sha512-xf3sF0a48Cg/mFYHKODEPQRFpt7jmUV/KMaDgdXU/TlluKB7kKV4aDxuQkCjXj9pVHtHGW7jhtcVVpwUn5Wa8A==",
+      "version": "0.51.2",
+      "resolved": "https://pkg.pr.new/@blocknote/react@2739",
+      "integrity": "sha512-0EpyHbGAZ2wPM8SE+uYAObkrpSFnibdDGEmoEAEWN8m4fz9sSqYCHMuni+AoiT7BP19NzcpBBR003YvfRYhmzw==",
       "license": "MPL-2.0",
       "dependencies": {
-        "@blocknote/core": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/core@ac52371",
+        "@blocknote/core": "https://pkg.pr.new/TypeCellOS/BlockNote/@blocknote/core@89669d2",
         "@emoji-mart/data": "^1.2.1",
         "@floating-ui/react": "^0.27.18",
         "@floating-ui/utils": "^0.2.10",
@@ -615,110 +619,6 @@
         "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
         "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
       }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/core": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.5.tgz",
-      "integrity": "sha512-657Xqcgf1IYWLkAmRDJKNSGdoS1AHJEgK6zHWHFJERQGIqHnwC7Fz7nvWs/NQhQVBkclQd0ERRdTCZ3XwRc1+g==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/pm": "3.23.5"
-      }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/extension-bubble-menu": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.5.tgz",
-      "integrity": "sha512-otcGwyVO6OfxdDPnbooZxYGrb+6q5WYmS+g2V+XGGNRn5oJgyY5pW0dqELIUJ66dosIIXXPyw2XqBDpMMY2kyQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.23.5",
-        "@tiptap/pm": "3.23.5"
-      }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/extension-floating-menu": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.5.tgz",
-      "integrity": "sha512-kP0bZKH/lxNogfvoIy/YJZ5gkty0OwqFVtQUwoc85vXYUfvy5Jh1VdO053tCE1iDzmvOITUpcb+MdWryP8dBxA==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "peerDependencies": {
-        "@floating-ui/dom": "^1.0.0",
-        "@tiptap/core": "3.23.5",
-        "@tiptap/pm": "3.23.5"
-      }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/pm": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.5.tgz",
-      "integrity": "sha512-9tgLdpTvNN0/fLP4RcNzbyQ0qjg9J2ahaFbQzgV5uvd+QMy8Xkg2IqKKnOoJJUAV3FDjGq3Yx0WrV2BGro9pfw==",
-      "license": "MIT",
-      "dependencies": {
-        "prosemirror-changeset": "^2.3.0",
-        "prosemirror-commands": "^1.6.2",
-        "prosemirror-dropcursor": "^1.8.1",
-        "prosemirror-gapcursor": "^1.3.2",
-        "prosemirror-history": "^1.4.1",
-        "prosemirror-keymap": "^1.2.2",
-        "prosemirror-model": "^1.24.1",
-        "prosemirror-schema-list": "^1.5.0",
-        "prosemirror-state": "^1.4.3",
-        "prosemirror-tables": "^1.6.4",
-        "prosemirror-transform": "^1.10.2",
-        "prosemirror-view": "^1.38.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/react": {
-      "version": "3.23.5",
-      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.5.tgz",
-      "integrity": "sha512-aEdKfJxoa6tCEV4FrnBqMQoUPwGcTWLaDzmP4fL1gR7E40rYDTiYNKoF1Ob+UimUpguAP6Emv1WlJa5oyI8FSw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/use-sync-external-store": "^0.0.6",
-        "fast-equals": "^5.3.3",
-        "use-sync-external-store": "^1.4.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/ueberdosis"
-      },
-      "optionalDependencies": {
-        "@tiptap/extension-bubble-menu": "^3.23.5",
-        "@tiptap/extension-floating-menu": "^3.23.5"
-      },
-      "peerDependencies": {
-        "@tiptap/core": "3.23.5",
-        "@tiptap/pm": "3.23.5",
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@blocknote/react/node_modules/@tiptap/react/node_modules/@types/use-sync-external-store": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
-      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
-      "license": "MIT"
     },
     "node_modules/@emoji-mart/data": {
       "version": "1.2.1",
@@ -1720,6 +1620,110 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tiptap/core": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.6.tgz",
+      "integrity": "sha512-MRB3pHz4Oxqmcawh0cQ5iOGdY5xtNYp/1CoK7hdTLzw5K0C6/gTC2VvanB1R4INaB6EpBkxG/GiWkVirDRnuXw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-bubble-menu": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bubble-menu/-/extension-bubble-menu-3.23.6.tgz",
+      "integrity": "sha512-Mwkyp9LkDHFbqmWRIkp63FinRxFu3ajC4qSb9t4mnHsb4kAdbNLLsGtbFg+le0SWk4CxGwAOwM7SzeJ+6UGqCA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@floating-ui/dom": "^1.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/extension-floating-menu": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-floating-menu/-/extension-floating-menu-3.23.6.tgz",
+      "integrity": "sha512-2kjuDcEq69lEcECl75xqY5MyzUSh2zcC5aLrpwP1WwhJz5bxsIFHiaps5AP6h9R4A+ZBj5b2haay2Y1wDUU3VA==",
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "peerDependencies": {
+        "@floating-ui/dom": "^1.0.0",
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6"
+      }
+    },
+    "node_modules/@tiptap/pm": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.6.tgz",
+      "integrity": "sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==",
+      "license": "MIT",
+      "dependencies": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      }
+    },
+    "node_modules/@tiptap/react": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/react/-/react-3.23.6.tgz",
+      "integrity": "sha512-Tw9KZkYqFMk3vaJAEQKqEYIO/iq3cSJe7OUEGBul4k4GaMQeLItLf5EYhUd0GIPXci1WVVPNntKJsHfX25M37w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "fast-equals": "^5.3.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/ueberdosis"
+      },
+      "optionalDependencies": {
+        "@tiptap/extension-bubble-menu": "^3.23.6",
+        "@tiptap/extension-floating-menu": "^3.23.6"
+      },
+      "peerDependencies": {
+        "@tiptap/core": "3.23.6",
+        "@tiptap/pm": "3.23.6",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tiptap/react/node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2141,16 +2145,6 @@
       "peer": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/isomorphic.js": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
-      "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "license": "MIT",
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
       }
     },
     "node_modules/js-tokens": {
@@ -2973,136 +2967,12 @@
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
     },
-    "node_modules/y-prosemirror": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
-      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.109"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "prosemirror-model": "^1.7.1",
-        "prosemirror-state": "^1.2.3",
-        "prosemirror-view": "^1.9.10",
-        "y-protocols": "^1.0.1",
-        "yjs": "^13.5.38"
-      }
-    },
-    "node_modules/y-prosemirror/node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
-    "node_modules/y-protocols": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
-      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.85"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      },
-      "peerDependencies": {
-        "yjs": "^13.0.0"
-      }
-    },
-    "node_modules/y-protocols/node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yjs": {
-      "version": "13.6.30",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
-      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lib0": "^0.2.99"
-      },
-      "engines": {
-        "node": ">=16.0.0",
-        "npm": ">=8.0.0"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
-    },
-    "node_modules/yjs/node_modules/lib0": {
-      "version": "0.2.117",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
-      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic.js": "^0.2.4"
-      },
-      "bin": {
-        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
-        "0gentesthtml": "bin/gentesthtml.js",
-        "0serve": "bin/0serve.js"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "type": "GitHub Sponsors ❤",
-        "url": "https://github.com/sponsors/dmonad"
-      }
     }
   }
 }

--- a/yhub-blocknote-demo/package.json
+++ b/yhub-blocknote-demo/package.json
@@ -11,9 +11,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@blocknote/core": "https://pkg.pr.new/@blocknote/core@ac52371",
-    "@blocknote/mantine": "https://pkg.pr.new/@blocknote/mantine@ac52371",
-    "@blocknote/react": "https://pkg.pr.new/@blocknote/react@ac52371",
+    "@blocknote/core": "https://pkg.pr.new/@blocknote/core@2739",
+    "@blocknote/mantine": "https://pkg.pr.new/@blocknote/mantine@2739",
+    "@blocknote/react": "https://pkg.pr.new/@blocknote/react@2739",
     "@y/prosemirror": "file:..",
     "@y/protocols": "^1.0.6-rc.1",
     "@y/websocket": "^4.0.0-rc.1",

--- a/yhub-blocknote-demo/src/yhub.js
+++ b/yhub-blocknote-demo/src/yhub.js
@@ -108,10 +108,6 @@ export const mapAttributionToMark = (format, attribution) => {
     out['y-attributed-format'] = {
       id: userIds[0] ?? null,
       'user-color': colorForUserIds(userIds),
-      type: 'modification',
-      attrName: null,
-      previousValue: null,
-      newValue: null
     }
   }
   return out

--- a/yhub-blocknote-demo/src/yhub.js
+++ b/yhub-blocknote-demo/src/yhub.js
@@ -107,7 +107,7 @@ export const mapAttributionToMark = (format, attribution) => {
     const userIds = [...(new Set(Object.values(attribution.format).flat()))]
     out['y-attributed-format'] = {
       id: userIds[0] ?? null,
-      'user-color': colorForUserIds(userIds),
+      'user-color': colorForUserIds(userIds)
     }
   }
   return out


### PR DESCRIPTION
This version of blocknote removes the `excludes: 'y-attributed-insert y-attributed-delete y-attributed-format'`, and replaces it with `excludes: ''`.
BlockNote allows these marks on all node types already.
