### PR TITLE
attributed nodes, required attr, failing test cases

### DIFF
--- a/src/sync-utils.js
+++ b/src/sync-utils.js
@@ -317,7 +317,7 @@ const applyNodeFormat = (tr, pos, format, attributedNodes) => {
     attributedVariant(canonicalNodeName(node.type.name), marksToFormattingAttributes(resultingMarks), attributedNodes, schema)
   ]
   if (targetType !== node.type) {
-    tr.setNodeMarkup(pos, targetType, node.attrs, resultingMarks)
+    tr.setNodeMarkup(pos, targetType, object.assign({ 'yjs-suggestion-node': true }, node.attrs), resultingMarks)
   } else {
     object.forEach(format ?? {}, (v, k) => {
       if (v == null) {
@@ -460,8 +460,13 @@ export const deltaToPNode = (d, schema, dformat, attributedNodes = defaultAttrib
   }
   const inputChildren = dc.flat(1)
   const inputMarks = formattingAttributesToMarks(dformat, schema)
+  const finalAttrs = canonical !== nodeType.name
+    ? object.assign({
+      'yjs-suggestion-node': true
+    }, attrs)
+    : attrs
   const pNode = nodeType.createAndFill(
-    attrs,
+    finalAttrs,
     inputChildren,
     inputMarks
   )

--- a/src/sync-utils.js
+++ b/src/sync-utils.js
@@ -317,6 +317,8 @@ const applyNodeFormat = (tr, pos, format, attributedNodes) => {
     attributedVariant(canonicalNodeName(node.type.name), marksToFormattingAttributes(resultingMarks), attributedNodes, schema)
   ]
   if (targetType !== node.type) {
+    // TODO this assumes that when flipping the node type, that the new type fits in the same position within the parent
+    // This is not always true and will fail with a single required node like BlockNote's blockContainer
     tr.setNodeMarkup(pos, targetType, object.assign({ 'yjs-suggestion-node': true }, node.attrs), resultingMarks)
   } else {
     object.forEach(format ?? {}, (v, k) => {

--- a/tests/attributed-nodes.test.js
+++ b/tests/attributed-nodes.test.js
@@ -16,7 +16,7 @@ const schema = new Schema({
     ...nodes,
     'paragraph--attributed': {
       content: 'inline*',
-      group: 'block',
+      group: 'block attributed',
       parseDOM: [{ tag: 'p[data-attributed]' }],
       toDOM () {
         return ['p', { 'data-attributed': 'true' }, 0]
@@ -25,10 +25,19 @@ const schema = new Schema({
     'heading--attributed': {
       attrs: { level: { default: 1 } },
       content: 'inline*',
-      group: 'block',
+      group: 'block attributed',
       defining: true,
       toDOM (node) {
         return ['h' + node.attrs.level, { 'data-attributed': 'true' }, 0]
+      }
+    },
+    container: {
+      attrs: { 'yjs-suggestion-node': { } },
+      content: 'attributed* block attributed*',
+      group: 'block',
+      parseDOM: [{ tag: 'container' }],
+      toDOM () {
+        return ['container', {}, 0]
       }
     }
   },
@@ -56,8 +65,9 @@ const assertDocJSON = (doc, expected, message) => {
  *
  * @param {AttributedNodesPredicate} attributedNodes
  * @param {string} baseContent
+ * @param {import('lib0/delta').Delta} [seedDelta]
  */
-const setup = (attributedNodes, baseContent) => {
+const setup = (attributedNodes, baseContent, seedDelta = delta.create().insert([delta.create('paragraph', {}, baseContent)]).done()) => {
   const doc = new Y.Doc({ gc: false, guid: 'base' })
   const suggestionDoc = new Y.Doc({ isSuggestionDoc: true, gc: false, guid: 'suggestions' })
   const suggestionModeDoc = new Y.Doc({ isSuggestionDoc: true, gc: false, guid: 'suggestions-edit' })
@@ -88,11 +98,32 @@ const setup = (attributedNodes, baseContent) => {
   const editor = mkView(suggestionModeDoc.get('prosemirror'), suggestionModeAM)
 
   doc.get('prosemirror').applyDelta(
-    delta.create().insert([delta.create('paragraph', {}, baseContent)]).done()
+    seedDelta
   )
 
   return { doc, suggestionModeDoc, base, viewer, editor }
 }
+
+/**
+ * Strip the reserved `--attributed` render suffix so a variant node name maps
+ * back to its canonical type. Mirrors `canonicalNodeName` in `sync-utils`.
+ *
+ * @param {string} name
+ * @return {string}
+ */
+const canonical = (name) =>
+  name.endsWith('--attributed') ? name.slice(0, -'--attributed'.length) : name
+
+/**
+ * A `container` seed delta holding a single `paragraph` child.
+ * @param {string} text
+ **/
+const containerWithParagraph = (text) =>
+  delta.create().insert([
+    delta.create('container', { 'yjs-suggestion-node': true }, [
+      delta.create('paragraph', {}, text)
+    ])
+  ]).done()
 
 /**
  * A block inserted in suggestion mode renders under its `--attributed` variant
@@ -244,4 +275,227 @@ export const testAcceptFlipsBackToCanonical = _tc => {
   assertDocJSON(base.state.doc, expected, 'base: suggestion merged')
   assertDocJSON(viewer.state.doc, expected, 'viewer: variant flipped back to canonical')
   assertDocJSON(editor.state.doc, expected, 'editor: variant flipped back to canonical')
+}
+
+/* -------------------------------------------------------------------------- *
+ *  Container nesting: flipping a *child* node type as a suggestion.
+ *
+ *  The `container` node declares `content: 'attributed* block attributed*'` and
+ *  carries the `yjs-suggestion-node` attr. The scenarios below nest a child
+ *  block inside a container and then change that child's type (paragraph <->
+ *  heading) in suggestion mode. The goal is to be able to flip the suggested
+ *  child change back and forth and have every peer (base / viewer / editor)
+ *  stay consistent.
+ *
+ *  NOTE: these cases are expected to surface sync/schema issues today - a
+ *  child-type flip in suggestion mode renders the original child as a deleted
+ *  `*--attributed` variant alongside the inserted new type, which can violate
+ *  the container's content expression and/or fail to round-trip to the viewer.
+ *  They are written against the *intended* converged state so they pin down the
+ *  target behaviour while the fix is developed.
+ * -------------------------------------------------------------------------- */
+
+/**
+ * Sanity baseline: a `container` seeded with a `paragraph` child syncs to all
+ * three peers unchanged (no attribution yet, so no variant rendering).
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testContainerSeedSyncs = _tc => {
+  const { base, viewer, editor } = setup(
+    (_name, kinds) => kinds.insert === true || kinds.delete === true || kinds.format === true,
+    '',
+    containerWithParagraph('child')
+  )
+
+  const expected = {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'child' }] }]
+    }]
+  }
+  assertDocJSON(base.state.doc, expected, 'base: container + child seeded')
+  assertDocJSON(viewer.state.doc, expected, 'viewer: container + child seeded')
+  assertDocJSON(editor.state.doc, expected, 'editor: container + child seeded')
+}
+
+/**
+ * Flip a container's child `paragraph` -> `heading` in suggestion mode.
+ *
+ * Intended converged state: every peer keeps a single child whose canonical
+ * type is now `heading`, rendered under its `heading--attributed` variant with
+ * a `y-attributed-format` mark, while the Y document still stores `heading`.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testContainerChildFlipParagraphToHeading = _tc => {
+  const { base, viewer, editor } = setup(
+    (_name, kinds) => kinds.insert === true || kinds.delete === true || kinds.format === true,
+    '',
+    containerWithParagraph('child')
+  )
+
+  t.assert(
+    editor.state.doc.child(0).child(0).type.name === 'paragraph',
+    'pre-flip: container has a paragraph child'
+  )
+
+  // Change the child block type in place (paragraph -> heading) as a suggestion.
+  // The container opens at pos 0, so its child block is at pos 1.
+  editor.dispatch(editor.state.tr.setNodeMarkup(
+    1, schema.nodes.heading, { level: 2 }
+  ))
+
+  // Base (no attribution) is untouched: still a canonical paragraph child.
+  assertDocJSON(base.state.doc, {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'child' }] }]
+    }]
+  }, 'base: child stays canonical paragraph')
+
+  // Editor & viewer both render the suggested heading variant, canonical type
+  // `heading` stored in Y. The child carries the format-change attribution.
+  const expected = {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{
+        type: 'heading--attributed',
+        attrs: { level: 2 },
+        marks: [{ type: 'y-attributed-format', attrs: { userIds: [], timestamp: null } }],
+        content: [{ type: 'text', text: 'child' }]
+      }]
+    }]
+  }
+  assertDocJSON(editor.state.doc, expected, 'editor: child flipped to heading variant')
+  assertDocJSON(viewer.state.doc, expected, 'viewer: child flip synced as heading variant')
+}
+
+/**
+ * Flip back and forth: paragraph -> heading -> paragraph within a container,
+ * all as suggestions. After flipping back the suggested child change should be
+ * gone and every peer should converge on the original canonical paragraph.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testContainerChildFlipBackAndForth = _tc => {
+  const { base, viewer, editor } = setup(
+    (_name, kinds) => kinds.insert === true || kinds.delete === true || kinds.format === true,
+    '',
+    containerWithParagraph('child')
+  )
+
+  // paragraph -> heading (child block is at pos 1, inside the container).
+  t.assert(
+    editor.state.doc.child(0).child(0).type.name === 'paragraph',
+    'pre-flip: container has a paragraph child'
+  )
+  editor.dispatch(editor.state.tr.setNodeMarkup(
+    1, schema.nodes.heading, { level: 2 }
+  ))
+
+  t.assert(
+    canonical(viewer.state.doc.child(0).child(0).type.name) === 'heading',
+    'after first flip: viewer child is a heading'
+  )
+
+  // heading -> paragraph (flip back)
+  t.assert(
+    canonical(editor.state.doc.child(0).child(0).type.name) === 'heading',
+    'mid-flip: container child is now a heading'
+  )
+  editor.dispatch(editor.state.tr.setNodeMarkup(
+    1, schema.nodes.paragraph, {}
+  ))
+
+  // Back to the original canonical paragraph everywhere - no residual variant
+  // or attribution mark on the child.
+  const original = {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'child' }] }]
+    }]
+  }
+  assertDocJSON(base.state.doc, original, 'base: unchanged after round-trip flip')
+  assertDocJSON(editor.state.doc, original, 'editor: child flipped back to paragraph')
+  assertDocJSON(viewer.state.doc, original, 'viewer: child flipped back to paragraph')
+}
+
+/**
+ * Accepting a container child-flip suggestion should merge it into the base
+ * doc: the child becomes a canonical `heading` (no variant, no marks) for all
+ * peers, including base.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testContainerChildFlipAccept = _tc => {
+  const { base, viewer, editor } = setup(
+    (_name, kinds) => kinds.insert === true || kinds.delete === true || kinds.format === true,
+    '',
+    containerWithParagraph('child')
+  )
+
+  // Child block is at pos 1, inside the container.
+  editor.dispatch(editor.state.tr.setNodeMarkup(
+    1, schema.nodes.heading, { level: 2 }
+  ))
+
+  YPM.acceptAllChanges()(viewer.state, viewer.dispatch)
+
+  const expected = {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{
+        type: 'heading',
+        attrs: { level: 2 },
+        content: [{ type: 'text', text: 'child' }]
+      }]
+    }]
+  }
+  assertDocJSON(base.state.doc, expected, 'base: child flip accepted into canonical heading')
+  assertDocJSON(viewer.state.doc, expected, 'viewer: child is canonical heading')
+  assertDocJSON(editor.state.doc, expected, 'editor: child is canonical heading')
+}
+
+/**
+ * Rejecting a container child-flip suggestion should discard it: every peer
+ * returns to the original canonical `paragraph` child.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testContainerChildFlipReject = _tc => {
+  const { base, viewer, editor } = setup(
+    (_name, kinds) => kinds.insert === true || kinds.delete === true || kinds.format === true,
+    '',
+    containerWithParagraph('child')
+  )
+
+  // Child block is at pos 1, inside the container.
+  editor.dispatch(editor.state.tr.setNodeMarkup(
+    1, schema.nodes.heading, { level: 2 }
+  ))
+
+  YPM.rejectAllChanges()(viewer.state, viewer.dispatch)
+
+  const original = {
+    type: 'doc',
+    content: [{
+      type: 'container',
+      attrs: { 'yjs-suggestion-node': true },
+      content: [{ type: 'paragraph', content: [{ type: 'text', text: 'child' }] }]
+    }]
+  }
+  assertDocJSON(base.state.doc, original, 'base: unchanged after reject')
+  assertDocJSON(viewer.state.doc, original, 'viewer: child flip rejected')
+  assertDocJSON(editor.state.doc, original, 'editor: child flip rejected')
 }


### PR DESCRIPTION
This PR introduces the required attribute that we talked about on call.

For ProseMirror to not automatically create these attribution nodes, it needs to have a required attribute which will force prosemirror's content fitting to bail when creating intermediate nodes (because the attribute is required but prosemirror has no default to set). This hack allowed us to not mess with prosemirror parsing rules and inject arbitrary nodes into positions of otherwise strict schemas.


This PR introduces some test cases which fail in the same way that BlockNote's schema is failing.

I’ve diagnosed the issue. The problem is that the deltaToTr assumes that a delta’s ops can be mapped 1:1 with a prosemirror step. But, in the case of an attributed node change this turns out to not be true. Let’s see an example:

```html
// Base
<blockContainer>
  <paragraph>abc</paragraph>
</blockContainer>
// Suggestion
<blockContainer>
  <paragraph—attribution>abc</paragraph--atribution>
  <heading>abc</heading>
</blockContainer>
```

But, the delta wants to:

```html
<modify>paragraph -> paragraph--atribution</modify>
<insert>heading>abc</insert>
```

But, in ProseMirror **each step must result in a valid document**, meaning:

* if you do the *modify* first, you may break the schema constraints of blockContainer

* if you do the *insert* first, you have the very issue we are trying to prevent (two nodes where one is allowed)

Some possible solutions are:

* In ProseMirror you can make arbitrary steps for operations you want to perform. We could make a custom ProseMirror step which represents this attribution node replacement in a single step (suggestion attribution step?)

  * This would require reading the delta ahead to make sure that it does an insert directly afterwards. So that you can safely collapse both delta ops into one pm step

* In ProseMirror each step has the abillity to merge with others (e.g. two inserts can be merged to be one longer insert). So, we could accumulate prosemirror steps (maybe a list), and only afterwards, merge the steps together and apply them if still valid. This should merge the two individually invalid steps into 1 valid replacement.
