### PR TITLE
refactor: diff options, export sync-utils, Command for pauseSync

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -4,9 +4,7 @@ import { absolutePositionToRelativePosition } from './positions.js'
 
 /**
  * Switch to pause mode (stop synchronization between prosemirror and ytype)
- * @param {import('prosemirror-state').EditorState} state
- * @param {((tr: import('prosemirror-state').Transaction) => void)?} dispatch
- * @returns {boolean}
+ * @type {import('prosemirror-state').Command}
  */
 export function pauseSync (state, dispatch) {
   const pluginState = ySyncPluginKey.getState(state)

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 export * from './sync-plugin.js'
 export * from './keys.js'
 export * from './positions.js'
-export { docToDelta, $prosemirrorDelta, defaultMapAttributionToMark, defaultAttributionConf, attributionMapperToConf, yattr2markname, pmToFragment, fragmentToPm } from './sync-utils.js'
+export * from './sync-utils.js'
 export * from './commands.js'
 export * from './undo-plugin.js'
 export * from './cursor-plugin.js'

--- a/src/sync-utils.js
+++ b/src/sync-utils.js
@@ -719,11 +719,12 @@ export const deltaToPNode = (d, schema, dformat, attributedNodes = defaultAttrib
 /**
  * @param {Node} beforeDoc
  * @param {Node} afterDoc
+ * @param {delta.DiffOptions} [options]
  */
-export const docDiffToDelta = (beforeDoc, afterDoc) => {
+export const docDiffToDelta = (beforeDoc, afterDoc, options) => {
   const initialDelta = nodeToDelta(beforeDoc)
   const finalDelta = nodeToDelta(afterDoc)
-  return delta.diff(initialDelta.done(), finalDelta.done())
+  return delta.diff(initialDelta.done(), finalDelta.done(), options)
 }
 
 /**


### PR DESCRIPTION
I needed to have custom compare on the docDiffToDelta function and not all of the sync-utils were being exported properly
