### PR TITLE
feat: `onInternalError` option to observe recovered sync errors

### DIFF
--- a/src/rdt/y-sync.js
+++ b/src/rdt/y-sync.js
@@ -3,6 +3,15 @@ import * as delta from 'lib0/delta'
 import { $prosemirrorDelta } from '../sync-utils.js'
 
 /**
+ * Default {@link YSyncRdt} `onInternalError` handler: log a console warning
+ * and move on.
+ *
+ * @param {string} context
+ * @param {unknown} err
+ */
+const defaultOnInternalError = (context, err) => console.warn(context, err)
+
+/**
  * The Y side of the sync binding: a thin lib0-`RDT` wrapper around a
  * {@link YType}, which implements the RDT interface natively — the `'delta'`
  * channel (with transaction origins, delivered through deleted parents, and
@@ -91,8 +100,15 @@ export class YSyncRdt extends ObservableV2 {
    * @param {any} opts.origin origin for Y transactions this RDT writes
    *   (typically the sync Plugin instance, so the undo plugin tracks them)
    * @param {NodeCompare?} [opts.compare] forwarded to every `delta.diff`
+   * @param {(context: string, err: unknown) => void} [opts.onInternalError]
+   *   called with a description of what failed and how the sync recovered
+   *   (`context`) plus the thrown error, for any error the sync recovered from
+   *   instead of rethrowing (see the last-resort catch in `applyDelta`).
+   *   Defaults to logging a console warning; providing a handler replaces the
+   *   warning, so hosts (test harnesses, error reporters) can surface these
+   *   instead of scraping the console.
    */
-  constructor ({ ytype, renderer, origin, compare = null }) {
+  constructor ({ ytype, renderer, origin, compare = null, onInternalError = defaultOnInternalError }) {
     super()
     if (ytype.doc == null) {
       throw new Error('[y/prosemirror]: the ytype must be integrated into a Y.Doc before binding')
@@ -101,6 +117,7 @@ export class YSyncRdt extends ObservableV2 {
     this.renderer = renderer
     this.origin = origin
     this.compare = compare ?? undefined
+    this.onInternalError = onInternalError
     this.$delta = $prosemirrorDelta
     this._applying = false
     /**
@@ -244,7 +261,7 @@ export class YSyncRdt extends ObservableV2 {
       // the ops before the failing one have already been applied — do NOT
       // rethrow; the fix below is computed from the actual post-write state
       // and heals both sides from whatever actually landed.
-      console.warn('[y/prosemirror] ytype.applyDelta failed - reverting the unappliable part of the change', err)
+      this.onInternalError('[y/prosemirror] ytype.applyDelta failed - reverting the unappliable part of the change', err)
     } finally {
       this._applying = false
     }

--- a/src/sync-plugin.js
+++ b/src/sync-plugin.js
@@ -75,6 +75,7 @@ const $maybeSyncPluginStateUpdate = $syncPluginStateUpdate.nullable
  * @param {AttributedNodesPredicate} [opts.attributedNodes] Optional predicate `(nodeName, kinds) => boolean`. When it returns `true` for an attributed node *and* a `{nodeName}--attributed` type exists in the schema, that node is rendered under the variant type (the `y-attributed-*` marks are still applied). `kinds` is `{ insert?, delete?, format? }`. The variant is a pure rendering concern - the canonical name is what is stored in the Y document. The predicate must be deterministic in `(nodeName, kinds)`.
  * @param {NodeCompare} [opts.customCompare] Optional predicate `(a, b) => boolean` that shifts the *diffing boundary*. To sync, y-prosemirror diffs the ProseMirror doc against the Y document as `lib0/delta` trees; lib0's `diff` decides for each candidate node pair whether to pair them (diff *in place* via a `modify` op) or to **replace the old subtree wholesale** (delete + insert). By default a pair is matched purely on node name (`a.name === b.name`). Supply this to move the boundary - e.g. make a `blockContainer` only pair when its first child type also matches (`(a, b) => a.name === b.name && (a.name !== 'blockContainer' || firstChildName(a) === firstChildName(b))`), so changing the first child replaces the whole container instead of editing it in place. Receives the raw `lib0/delta` nodes `(fromNode, toNode)` (each exposing `.name`, `.attrs`, `.children`) and is forwarded to `lib0/delta.diff` as its `compare` option, applied recursively down the tree. Generally keep the `a.name === b.name` check; omit the option to keep lib0's name-only default.
  * @param {Array<(($d: s.Schema<any>) => dt.Template<any, any>)>} [opts.transformers] Optional custom transformer stages, slotted into the pipeline **between** `fullAttributions` and `attributionToFormat`, in data→view (`applyA`) order. Each is a `$d => Template` factory (see `lib0/delta/transformer`); the input schema is threaded left to right. Custom transformers see changes in canonical document space, with the complete accumulated attribution on every attribution-bearing op.
+ * @param {(context: string, err: unknown) => void} [opts.onInternalError] Called with a description of what failed and how the sync recovered (`context`) plus the thrown error, for any error the sync recovered from instead of rethrowing (see {@link YSyncRdt}). Defaults to logging a console warning; providing a handler replaces the warning.
  * @returns {Plugin}
  */
 export function syncPlugin (opts = {}) {
@@ -130,7 +131,8 @@ export function syncPlugin (opts = {}) {
           ytype,
           renderer,
           origin: ySyncPluginKey.get(view.state),
-          compare
+          compare,
+          onInternalError: opts.onInternalError
         })
         const pmRdt = new ProsemirrorRdt({
           view,

--- a/tests/y-sync-rdt.test.js
+++ b/tests/y-sync-rdt.test.js
@@ -278,3 +278,37 @@ export const testInitRaceFirstRenderReplacesGatedSkeleton = _tc => {
     view2.destroy()
   }
 }
+
+/**
+ * `onInternalError` observes errors the last-resort catch in `applyDelta`
+ * recovers from. The default logs a console warning; a provided handler
+ * replaces the warning, so hosts can surface these failures (fail a test,
+ * report to an error tracker) instead of scraping the console.
+ *
+ * @param {t.TestCase} _tc
+ */
+export const testYSyncRdtOnInternalErrorReplacesWarn = _tc => {
+  const doc = new Y.Doc({ gc: false })
+  const ytype = doc.get('prosemirror')
+  /** @type {Array<[string, unknown]>} */
+  const seen = []
+  const rdt = new YSyncRdt({ ytype, renderer: null, origin: PLUGIN_ORIGIN, onInternalError: (context, err) => seen.push([context, err]) })
+  /** @type {Array<unknown>} */
+  const warned = []
+  const originalWarn = console.warn
+  const originalApply = ytype.applyDelta.bind(ytype)
+  console.warn = (/** @type {Array<unknown>} */ ...args) => warned.push(args)
+  // @ts-ignore - force the next Y-side apply to throw, entering the catch
+  ytype.applyDelta = () => { throw new Error('boom') }
+  try {
+    rdt.applyDelta(delta.create().insert([paragraph('x')]).done(), null)
+  } finally {
+    // @ts-ignore
+    ytype.applyDelta = originalApply
+    console.warn = originalWarn
+  }
+  t.assert(seen.length === 1, 'the handler received the recovered error')
+  t.assert(seen[0][0].includes('applyDelta failed'), 'the handler received the failure context')
+  t.assert(seen[0][1] instanceof Error && seen[0][1].message === 'boom', 'the handler received the original error object')
+  t.assert(warned.length === 0, 'a provided handler replaces the default console warning')
+}


### PR DESCRIPTION
## Motivation

`YSyncRdt.applyDelta` has a last-resort catch: if the Y-side apply throws mid-transact, it reverts the unappliable part of the change and logs

```
[y/prosemirror] ytype.applyDelta failed - reverting the unappliable part of the change
```

The recovery itself is great — but the *only* signal is a console warning. In BlockNote this let a real bug (an editor-side `removeBlocks` throwing during a re-rendered version diff) stay invisible for two months: the UI silently stopped updating, nothing errored, and no test harness could observe the failure short of scraping the console.

## Change

Adds an `onInternalError?: (err: unknown) => void` option to `YSyncRdt` (threaded through `syncPlugin` opts):

- **Default behavior is unchanged**: `onInternalError` defaults to the existing `console.warn` call, byte-identical message.
- **Providing a handler replaces the warning**, handing the host the original error object (with stack) — so apps can report it to error trackers and test harnesses can fail loudly on it, without double-reporting.

Includes a unit test (`testYSyncRdtOnInternalErrorReplacesWarn`) covering both the handler delivery and the warn suppression. `npm test` (125/125) and `npm run lint` pass.

Happy to adjust naming/placement — and if this direction is right, the same hook could later serve other recovered-error sites (e.g. the cursor-plugin's selection-encode catch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
